### PR TITLE
fix: guard against --max-model-len > max_position_embeddings crash on first inference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,5 +240,13 @@ RUN rm -f /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 \
  && rm /tmp/libnccl.stripped.so
 
 COPY build-metadata.yaml /workspace/build-metadata.yaml
+
+# Preflight wrapper for `vllm serve` that validates --max-model-len against
+# the model's max_position_embeddings before launch. Prevents a silent CUDA
+# device-side assert crash on first inference. See issue #7.
+# Invoke as: vllm-serve-safe <model> --max-model-len N [other flags...]
+COPY scripts/vllm-serve-safe.sh /usr/local/bin/vllm-serve-safe
+RUN chmod +x /usr/local/bin/vllm-serve-safe
+
 # No ENTRYPOINT - users run: docker run ... <image> vllm serve ...
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,60 @@ CI triggers on changes to `versions.env`, `Dockerfile`, `locks/`, `scripts/`,
 or `checksums/`. A green build publishes updated image tags and creates a
 GitHub Release automatically.
 
+## `--max-model-len` and `max_position_embeddings`
+
+vLLM does **not** hard-cap `--max-model-len` at the model's `max_position_embeddings`. It logs a warning at startup and loads anyway. The first inference request then triggers a CUDA device-side assert that kills the engine — even with `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`. On the GB10, where a 60+ GB model takes 13–15 minutes to load over NFS, this produces a painful crash loop.
+
+See [issue #7](https://github.com/timothystewart6/vllm-gb10/issues/7) for the full trace and root cause.
+
+### Known-safe values
+
+| Model | `max_position_embeddings` |
+|-------|--------------------------|
+| `Qwen/Qwen3-32B` | 40,960 |
+| `Qwen/Qwen3-14B` | 40,960 |
+| `Qwen/Qwen3-8B` | 40,960 |
+| `Qwen/Qwen2.5-32B-Instruct` | 32,768 |
+| `meta-llama/Llama-3.3-70B-Instruct` | 131,072 |
+| `meta-llama/Llama-3.1-8B-Instruct` | 131,072 |
+| `mistralai/Mistral-Small-Instruct-2409` | 32,768 |
+| `google/gemma-3-27b-it` | 131,072 |
+| `microsoft/Phi-4` | 16,384 |
+| `deepseek-ai/DeepSeek-V3` | 163,840 |
+
+Check any model without downloading weights:
+
+```bash
+python3 -c "
+from huggingface_hub import hf_hub_download
+import json
+cfg = json.load(open(hf_hub_download('Qwen/Qwen3-32B', 'config.json')))
+print(cfg['max_position_embeddings'])
+"
+```
+
+### Preflight wrapper
+
+This image ships `vllm-serve-safe` — a thin wrapper around `vllm serve` that validates `--max-model-len` before launch:
+
+```bash
+# Default: refuse to start if --max-model-len exceeds the model's limit
+docker run --gpus all \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  ghcr.io/timothystewart6/vllm-gb10:latest \
+  vllm-serve-safe Qwen/Qwen3-32B --max-model-len 65536
+# [vllm-serve-safe] REFUSING TO START. max_position_embeddings=40960 requested=65536
+
+# Or auto-clamp to the model's actual maximum:
+docker run --gpus all -e VLLM_GB10_AUTOCLAMP=1 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  ghcr.io/timothystewart6/vllm-gb10:latest \
+  vllm-serve-safe Qwen/Qwen3-32B --max-model-len 65536
+# [vllm-serve-safe] clamping --max-model-len 65536 -> 40960
+```
+
+All other flags pass through unchanged. `vllm serve` still works as before — `vllm-serve-safe` is strictly opt-in.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Security issues: [SECURITY.md](SECURITY.md).

--- a/scripts/vllm-serve-safe.sh
+++ b/scripts/vllm-serve-safe.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# scripts/vllm-serve-safe.sh
+#
+# Preflight wrapper around `vllm serve` that prevents the silent
+# --max-model-len > max_position_embeddings foot-gun.
+#
+# BACKGROUND
+# ----------
+# vLLM warns at startup if --max-model-len exceeds the model's
+# max_position_embeddings, then loads anyway. The first inference
+# request triggers a CUDA device-side assert on the RoPE kernel:
+#
+#   Assertion `index out of bounds: 0 <= tmp16 < N` failed.
+#   terminate called after throwing an instance of 'c10::AcceleratorError'
+#     what():  CUDA error: device-side assert triggered
+#   EngineDeadError
+#
+# Because the GB10 loads a 61 GB model from NFS (~13-15 min per restart),
+# this creates a particularly painful crash loop: load → first request →
+# crash → reload → repeat. VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 suppresses the
+# warning but does NOT prevent the crash. See issue #7.
+#
+# BEHAVIOR
+# --------
+#   Default:               hard error before vLLM starts (exit 65)
+#   VLLM_GB10_AUTOCLAMP=1: silently clamp --max-model-len to model max
+#   No --max-model-len:    no-op pass-through to `vllm serve`
+#
+# USAGE
+# -----
+#   docker run --gpus all -v ~/.cache/huggingface:/root/.cache/huggingface \
+#     ghcr.io/timothystewart6/vllm-gb10:latest \
+#     vllm-serve-safe Qwen/Qwen3-32B --max-model-len 65536 [other flags...]
+#
+#   # Auto-clamp instead of refusing:
+#   docker run --gpus all -e VLLM_GB10_AUTOCLAMP=1 \
+#     -v ~/.cache/huggingface:/root/.cache/huggingface \
+#     ghcr.io/timothystewart6/vllm-gb10:latest \
+#     vllm-serve-safe Qwen/Qwen3-32B --max-model-len 65536
+
+set -euo pipefail
+
+log() { printf '[vllm-serve-safe] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 64; }
+
+# ---------------------------------------------------------------------------
+# Parse argv: find the model id (first non-flag positional) and the value
+# of --max-model-len if present.
+# ---------------------------------------------------------------------------
+MODEL=""
+MAX_LEN=""
+MAX_LEN_IDX=-1
+ARGS=("$@")
+
+i=0
+while [[ $i -lt ${#ARGS[@]} ]]; do
+  a="${ARGS[$i]}"
+  case "$a" in
+    --max-model-len)
+      MAX_LEN="${ARGS[$(( i+1 ))]:-}"
+      MAX_LEN_IDX=$(( i+1 ))
+      i=$(( i+2 )); continue ;;
+    --max-model-len=*)
+      MAX_LEN="${a#*=}"
+      MAX_LEN_IDX=$i
+      i=$(( i+1 )); continue ;;
+    -*)
+      next="${ARGS[$(( i+1 ))]:-}"
+      [[ -n "$next" && "$next" != -* ]] && i=$(( i+2 )) || i=$(( i+1 ))
+      continue ;;
+    *)
+      [[ -z "$MODEL" ]] && MODEL="$a"
+      i=$(( i+1 )) ;;
+  esac
+done
+
+if [[ -z "$MAX_LEN" ]]; then
+  log "no --max-model-len; passing through"
+  exec vllm serve "$@"
+fi
+
+[[ -n "$MODEL" ]] || die "--max-model-len set but model id could not be parsed from argv"
+
+# ---------------------------------------------------------------------------
+# Resolve config.json. Two cases:
+#   1. Local path (starts with / or .): read directly.
+#   2. HF repo id: look in HF cache, else fetch just config.json via hub.
+# ---------------------------------------------------------------------------
+config_json=""
+
+if [[ "$MODEL" == /* || "$MODEL" == .* ]]; then
+  config_json="$MODEL/config.json"
+  [[ -f "$config_json" ]] || die "no config.json at $config_json"
+else
+  hf_home="${HF_HOME:-${HOME}/.cache/huggingface}"
+  cached="$(find "$hf_home/hub" -path "*models--${MODEL//\//--}*/snapshots/*/config.json" 2>/dev/null | head -n1)"
+  if [[ -n "$cached" ]]; then
+    config_json="$cached"
+  else
+    log "config.json not in HF cache; fetching via huggingface_hub"
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    python3 - "$MODEL" "$tmp" <<'PY'
+import sys
+from huggingface_hub import hf_hub_download
+model, dest = sys.argv[1], sys.argv[2]
+print(hf_hub_download(repo_id=model, filename="config.json", local_dir=dest))
+PY
+    config_json="$tmp/config.json"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Extract max_position_embeddings. Handles top-level and text_config nesting
+# (used by some multimodal models).
+# ---------------------------------------------------------------------------
+model_max="$(python3 - "$config_json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    c = json.load(f)
+for key in ("max_position_embeddings",):
+    if key in c:
+        print(c[key]); sys.exit(0)
+tc = c.get("text_config") or {}
+if "max_position_embeddings" in tc:
+    print(tc["max_position_embeddings"]); sys.exit(0)
+sys.exit(2)
+PY
+)" || die "could not find max_position_embeddings in $config_json"
+
+log "model=$MODEL  max_position_embeddings=$model_max  requested=$MAX_LEN"
+
+# Within bounds — pass through unchanged.
+[[ "$MAX_LEN" -le "$model_max" ]] && exec vllm serve "$@"
+
+# Over limit: clamp or refuse.
+if [[ "${VLLM_GB10_AUTOCLAMP:-0}" == "1" ]]; then
+  log "VLLM_GB10_AUTOCLAMP=1: clamping --max-model-len $MAX_LEN -> $model_max"
+  ARGS[$MAX_LEN_IDX]="$model_max"
+  exec vllm serve "${ARGS[@]}"
+fi
+
+cat >&2 <<EOF
+[vllm-serve-safe] REFUSING TO START.
+
+  Model:                       $MODEL
+  max_position_embeddings:     $model_max
+  --max-model-len requested:   $MAX_LEN
+
+vLLM will warn but load anyway, then crash on the first inference request
+with a CUDA device-side assert. VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 hides the
+warning but does not prevent the crash.
+
+Fix one of:
+  - Lower --max-model-len to <= $model_max
+  - Set VLLM_GB10_AUTOCLAMP=1 to auto-clamp silently
+  - Use a model variant with YaRN/NTK RoPE scaling if you need longer context
+EOF
+exit 65

--- a/tests/test-max-model-len-guard.sh
+++ b/tests/test-max-model-len-guard.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# tests/test-max-model-len-guard.sh
+#
+# Unit tests for scripts/vllm-serve-safe.sh.
+# No GPU, no vLLM, no model weights required — stubs `vllm` on PATH
+# and uses a local config.json fixture.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/vllm-serve-safe.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# Fixture: model directory with max_position_embeddings=40960 (Qwen3-32B).
+mkdir -p "$work/model"
+cat > "$work/model/config.json" <<'JSON'
+{"max_position_embeddings": 40960, "model_type": "qwen3"}
+JSON
+
+# Stub `vllm` so exec calls are observable without a real binary.
+mkdir -p "$work/bin"
+cat > "$work/bin/vllm" <<'SH'
+#!/usr/bin/env bash
+printf 'STUB_VLLM:'; printf ' %s' "$@"; printf '\n'
+SH
+chmod +x "$work/bin/vllm"
+export PATH="$work/bin:$PATH"
+
+pass() { printf 'ok  %s\n' "$1"; }
+fail() { printf 'FAIL %s: %s\n' "$1" "$2" >&2; exit 1; }
+
+# 1. Under limit passes through unchanged.
+out="$("$WRAPPER" "$work/model" --max-model-len 32768 2>/dev/null)"
+[[ "$out" == *"32768"* ]] || fail "under-limit" "expected 32768 in: $out"
+pass "under-limit passes through"
+
+# 2. Exactly at limit passes through.
+out="$("$WRAPPER" "$work/model" --max-model-len 40960 2>/dev/null)"
+[[ "$out" == *"40960"* ]] || fail "at-limit" "expected 40960 in: $out"
+pass "at-limit passes through"
+
+# 3. Over limit with no autoclamp → exit 65 + REFUSING message.
+"$WRAPPER" "$work/model" --max-model-len 65536 >/dev/null 2>"$work/err" && \
+  fail "over-limit-refuse" "expected non-zero exit" || true
+grep -q "REFUSING" "$work/err" || fail "over-limit-refuse" "no REFUSING message in stderr"
+pass "over-limit refuses with REFUSING message"
+
+# 4. VLLM_GB10_AUTOCLAMP=1 rewrites to model max.
+out="$(VLLM_GB10_AUTOCLAMP=1 "$WRAPPER" "$work/model" --max-model-len 65536 2>/dev/null)"
+[[ "$out" == *"40960"* ]]  || fail "autoclamp" "expected clamped value 40960: $out"
+[[ "$out" != *"65536"* ]]  || fail "autoclamp" "original oversized value leaked: $out"
+pass "VLLM_GB10_AUTOCLAMP=1 clamps to model max"
+
+# 5. --max-model-len=VALUE (equals form) is handled.
+out="$("$WRAPPER" "$work/model" --max-model-len=32768 2>/dev/null)"
+[[ "$out" == *"32768"* ]] || fail "equals-form" "expected 32768 in: $out"
+pass "--max-model-len=VALUE form parsed correctly"
+
+# 6. No --max-model-len → pure pass-through, no flag injected.
+out="$("$WRAPPER" "$work/model" --port 8000 2>/dev/null)"
+[[ "$out" != *"--max-model-len"* ]] || fail "no-flag" "wrapper injected unwanted flag: $out"
+pass "no --max-model-len passes through without modification"
+
+printf '\nall 6 tests passed\n'


### PR DESCRIPTION
## What this fixes

Running a model with `--max-model-len` set above the model's actual `max_position_embeddings` causes a CUDA device-side assert on the **first inference request**, killing the vLLM engine:

```
Assertion `index out of bounds: 0 <= tmp16 < 40960` failed.
terminate called after throwing an instance of 'c10::AcceleratorError'
  what():  CUDA error: device-side assert triggered
EngineDeadError
```

vLLM logs a warning at startup and loads anyway. `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` hides the warning but **does not prevent the crash**. Closes #7.

## How we discovered this

We run an NVIDIA DGX Spark (Grace-Blackwell GB10, 128 GiB unified memory) as a dedicated inference node for LLM workloads — specifically running the [LongMemEval benchmark](https://github.com/xiaowu0162/LongMemEval) against a local memory system. The Qwen3-32B model (61 GB) loads from NFS at ~47 sec/shard, roughly 13–15 minutes per cold start.

Our fleet config had `--max-model-len 131072`. After an API key rotation forced a container restart, the backend appeared healthy: all 17 safetensor shards loaded, the vLLM process came up, port 8000 opened, the health endpoint returned 200. Then the first real inference request landed — and the process died instantly with the RoPE kernel assertion above.

Because the container auto-restarts (via our ai-fleet watcher), this created a crash loop: **load 15 min → first request → crash → reload → repeat**. The loop ran through 3+ cycles before the root cause was identified. Searching the vLLM issue tracker for the assert text eventually surfaced that `max_position_embeddings` for Qwen3-32B is 40960, not 131072.

The fix was a one-line config change (`--max-model-len 40960`). But the path to finding it was expensive: the warning vLLM emits at startup is easy to miss in 15 minutes of startup logs, and `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` actively misleads users into thinking they've resolved it.

## What this PR adds

**`scripts/vllm-serve-safe.sh`** — preflight wrapper. Reads `config.json` from the model directory or HF cache (fetching only that one file if needed), validates `--max-model-len`, and either refuses to start (default, exit 65) or auto-clamps to the model's actual max (`VLLM_GB10_AUTOCLAMP=1`). Pure pass-through if `--max-model-len` is not set. No change to the existing `vllm serve` invocation contract — wrapper is opt-in.

**`tests/test-max-model-len-guard.sh`** — 6 unit tests with no GPU, no vLLM, no weights required. Stubs `vllm` binary. Tests: under-limit pass-through, at-limit pass-through, over-limit refusal (exit 65), autoclamp rewrite, `--max-model-len=VALUE` form, no-flag pass-through.

**Dockerfile** — `COPY scripts/vllm-serve-safe.sh /usr/local/bin/vllm-serve-safe` added to runner stage. No ENTRYPOINT change.

**README** — `--max-model-len` section with known-safe values for 10 common models, a one-liner to check any model's `config.json` without downloading weights, and usage examples for the wrapper.

## Testing

### Test output

```
ok  under-limit passes through
ok  at-limit passes through
ok  over-limit refuses with REFUSING message
ok  VLLM_GB10_AUTOCLAMP=1 clamps to model max
ok  --max-model-len=VALUE form parsed correctly
ok  no --max-model-len passes through without modification

all 6 tests passed
```

Run yourself (no GPU, no model weights, no vLLM install required):

```bash
bash tests/test-max-model-len-guard.sh
```

Validated on the DGX Spark: with the wrapper in autoclamp mode, `--max-model-len 131072` is rewritten to `40960` before vLLM starts; inference proceeds correctly; no CUDA assert.

## Upstream

This is also worth filing on `vllm-project/vllm` as a `--max-model-len-policy={error,clamp,warn}` flag (defaulting to `error`, auto-downgraded to `warn` when `rope_scaling` is configured). Happy to write that PR too if there's interest.