### PR TITLE
fix(ci): prevent [skip ci] from suppressing build-image on squash merge

### DIFF
--- a/.github/workflows/run-bump.yaml
+++ b/.github/workflows/run-bump.yaml
@@ -27,6 +27,11 @@ permissions:
 
 jobs:
   bump:
+    # Skip if the push was made by the bot itself to avoid an infinite loop
+    # (bot commits back resolved SHAs -> would re-trigger this workflow).
+    # Do NOT use [skip ci] in the commit message: it bleeds into squash merge
+    # commits on main and suppresses build-image.yaml.
+    if: github.actor != 'github-actions[bot]'
     runs-on: [self-hosted, linux, ARM64, dgx-spark]
     timeout-minutes: 30
 
@@ -50,6 +55,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "Nothing changed - bump.sh was a no-op (all pins already current)."
           else
-            git commit -m "chore(bump): resolve SHAs and regenerate lockfiles [skip ci]"
+            git commit -m "chore(bump): resolve SHAs and regenerate lockfiles"
             git push origin HEAD:${{ github.head_ref }}
           fi


### PR DESCRIPTION
## Problem

`run-bump.yaml` commits back resolved SHAs to PR branches with `[skip ci]` in the message to prevent an infinite trigger loop. However, when that PR is squash-merged to `main`, GitHub combines all commit messages into one squash commit - including the bot's `[skip ci]` line. This causes `build-image.yaml` to be suppressed on every deps bump merge.

This is what happened with #12: the build never triggered automatically and had to be kicked off manually.

## Fix

- Add `if: github.actor != 'github-actions[bot]'` to the `bump` job in `run-bump.yaml` - this is the standard GitHub-recommended way to prevent bot-triggered loops without poisoning commit messages
- Remove `[skip ci]` from the bump commit message entirely