### PR TITLE
fix(ci): remove build-image.yaml from its own path trigger

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -37,7 +37,6 @@ on:
       - scripts/build-args.sh
       - checksums/**
       - tests/**
-      - .github/workflows/build-image.yaml
 
 concurrency:
   group: dgx-spark


### PR DESCRIPTION
## Problem

`.github/workflows/build-image.yaml` was listed in its own `push.paths` filter. Every Dependabot action SHA bump (e.g. `actions/checkout`, `softprops/action-gh-release`) touches this file and was triggering a full ~1 hour image build with zero artifact change.

## Fix

Remove `.github/workflows/build-image.yaml` from the path filter. Structural workflow changes can be tested on-demand via `workflow_dispatch` - they are rare enough that manual triggering is the right tradeoff.