### PR TITLE
fix(ci): allow both Sparks to build in parallel

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -37,7 +37,6 @@ on:
       - scripts/build-args.sh
       - checksums/**
       - tests/**
-      - .github/workflows/build-image.yaml
 
 concurrency:
   group: dgx-spark

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -38,9 +38,8 @@ on:
       - checksums/**
       - tests/**
 
-concurrency:
-  group: dgx-spark
-  cancel-in-progress: false
+# No workflow-level concurrency limit: each self-hosted runner handles exactly
+# one job at a time (GitHub enforces this), so two Sparks can build in parallel.
 
 permissions:
   contents: write


### PR DESCRIPTION
## Change

Remove the `concurrency: group: dgx-spark` block from `build-image.yaml`.

Previously all builds were serialized through a single queue - even with two idle Sparks, a second build would wait for the first to finish. With two separate physical runners, this was unnecessary.

GitHub's runner architecture already enforces 1 job per runner at a time. With this change, up to 2 builds can run simultaneously (one per Spark), and a 3rd will queue until a Spark is free.