### PR TITLE
docs(readme): pin build badge to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vllm-gb10
 
-[![Build](https://github.com/timothystewart6/vllm-gb10/actions/workflows/build-image.yaml/badge.svg)](https://github.com/timothystewart6/vllm-gb10/actions/workflows/build-image.yaml)
+[![Build](https://github.com/timothystewart6/vllm-gb10/actions/workflows/build-image.yaml/badge.svg?branch=main)](https://github.com/timothystewart6/vllm-gb10/actions/workflows/build-image.yaml)
 [![Latest release](https://img.shields.io/github/v/release/timothystewart6/vllm-gb10)](https://github.com/timothystewart6/vllm-gb10/releases/latest)
 [![GHCR](https://img.shields.io/badge/ghcr.io-vllm--gb10-blue)](https://github.com/timothystewart6/vllm-gb10/pkgs/container/vllm-gb10)
 


### PR DESCRIPTION
- Add `?branch=main` to the build badge URL so it always reflects the main branch status, regardless of cancelled runs on other branches