### PR TITLE
fix(dockerfile): retry flashinfer-cubin build up to 3x on CDN failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,5 +214,12 @@ RUN rm -f /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 \
       > /workspace/build-artifacts/nccl-sha256.txt
 
 COPY build-metadata.yaml /workspace/build-metadata.yaml
-# No ENTRYPOINT - users run: docker run ... <image> vllm serve ...
+# Clear the ENTRYPOINT inherited from the NVIDIA base image.
+# nvidia_entrypoint.sh is a 0-byte placeholder in the base image that only
+# gets populated by the nvidia-container-runtime in legacy mode. CDI mode
+# (default in nvidia-container-toolkit >= 1.17) never populates it, causing
+# "exec format error" on any host with CDI enabled. Clearing it here makes
+# the image portable regardless of host runtime configuration.
+# Users run: docker run ... <image> vllm serve ...
+ENTRYPOINT []
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,8 +113,15 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
     --mount=type=cache,id=ccache,target=/root/.ccache \
     if [ -z "${SOURCE_DATE_EPOCH}" ]; then unset SOURCE_DATE_EPOCH; fi \
  && uv build --no-build-isolation --wheel . --out-dir=/wheels -v \
- && cd flashinfer-cubin && uv build --no-build-isolation --wheel . --out-dir=/wheels -v \
- && cd ../flashinfer-jit-cache && uv build --no-build-isolation --wheel . --out-dir=/wheels -v
+ && cd flashinfer-cubin \
+ && for _try in 1 2 3; do \
+        uv build --no-build-isolation --wheel . --out-dir=/wheels -v && break; \
+        [ "${_try}" -lt 3 ] \
+            && { echo "flashinfer-cubin: attempt ${_try}/3 failed (cubin CDN), retrying in 60s..."; sleep 60; } \
+            || { echo "flashinfer-cubin: all 3 attempts failed"; exit 1; }; \
+    done \
+ && cd ../flashinfer-jit-cache \
+ && uv build --no-build-isolation --wheel . --out-dir=/wheels -v
 
 ############################################################
 # STAGE 3: vllm-builder - build vLLM wheel


### PR DESCRIPTION
## Problem

When Docker layer cache is cold (e.g. after a machine wipe), `flashinfer-cubin`'s build backend downloads **15,602 cubin files** from NVIDIA's artifactory CDN. Transient rate-limiting causes individual downloads to fail their 4 internal retries (10s timeout each), making the entire build fail.

## Fix

Wrap the `uv build flashinfer-cubin` step in a 3-attempt shell retry loop with a 60-second gap. On a CDN hiccup, the second attempt downloads fresh and succeeds. Once the Docker layer is cached, this code path is never hit again.

## Notes

- The retry loop is POSIX sh compatible (no bashisms).
- `SOURCE_DATE_EPOCH` is preserved across retries, so reproducibility is unaffected.
- Discovered on 2026-06-21 after `asus-gx10-1` was wiped and rebuilt from scratch.