### PR TITLE
feat(pr-body): extract shared diff logic and generate dynamic PR bodies

### DIFF
--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -63,6 +63,11 @@ jobs:
             echo "has-changes=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Build PR body
+        id: pr-body
+        if: steps.changes.outputs.has-changes == 'true'
+        run: scripts/generate-pr-body.sh > /tmp/pr-body.md
+
       - name: Create Pull Request
         if: steps.changes.outputs.has-changes == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
@@ -70,6 +75,6 @@ jobs:
           token: ${{ secrets.RELEASE_MONITOR_PAT }}
           commit-message: 'chore(deps): bump upstream dependencies'
           title: 'chore(deps): bump upstream dependencies'
-          body: 'Automated upstream release monitor detected new dependency releases. This PR will trigger bump.sh on the Spark to resolve COMMIT SHAs and regenerate lockfiles.'
+          body-path: /tmp/pr-body.md
           branch: deps/bump-${{ github.run_number }}
           delete-branch: true

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -17,6 +17,8 @@ on:
     paths:
       - scripts/generate-release-notes.sh
       - tests/test-release-notes-scenarios.py
+      - tests/test-pr-body-generation.py
+      - .github/workflows/monitor-upstream-releases.yaml
   workflow_dispatch:
 
 permissions:
@@ -36,6 +38,9 @@ jobs:
 
       - name: Run release-notes test harness
         run: python3 tests/test-release-notes-scenarios.py
+
+      - name: Run PR body generation test harness
+        run: python3 tests/test-pr-body-generation.py
 
       - name: Verify output is well-formed
         run: |

--- a/scripts/generate-pr-body.sh
+++ b/scripts/generate-pr-body.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/generate-pr-body.sh
+#
+# Generates a markdown PR body for the automated dependency bump PR.
+# Compares the working tree against origin/main and lists all changes:
+#   - versions.env variable changes (with human-readable labels)
+#   - lockfile hash changes (apt, python-bootstrap, python-build, python-runtime)
+#   - apt snapshot date changes (when applicable)
+#
+# Uses the shared versions_diff.py module (same labels and formatting as
+# generate-release-notes.sh).
+#
+# Usage:
+#   scripts/generate-pr-body.sh > /tmp/pr-body.md
+#
+# Exit code: 0 on success, 1 if no changes detected (body still produced).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Determine what to diff against (origin/main or HEAD~1 as fallback)
+BASEREF="origin/main"
+if ! git rev-parse --verify "${BASEREF}" > /dev/null 2>&1; then
+  BASEREF="HEAD~1"
+fi
+
+# Check if there are any changes to versions.env or lockfiles
+if git diff --exit-code "${BASEREF}" -- versions.env locks/ > /dev/null 2>&1; then
+  printf 'Automated upstream release monitor detected no changes.\n'
+  exit 1
+fi
+
+export REPO_ROOT
+python3 - <<'PYEOF'
+import os, subprocess, sys, hashlib, re, textwrap
+
+repo_root = os.environ["REPO_ROOT"]
+sys.path.insert(0, os.path.join(repo_root, "scripts"))
+from versions_diff import COMPONENT_LABELS, diff_from_git_diff, format_changes_with_lockfiles
+
+baseref = os.environ.get("BASEREF", "origin/main")
+
+# 1. Parse versions.env diff
+diff = subprocess.run(
+    ["git", "diff", baseref, "--", "versions.env"],
+    capture_output=True, text=True, check=True,
+).stdout
+changes = diff_from_git_diff(diff)
+
+# 2. Check lockfile changes
+lockfiles = [
+    ("locks/apt-packages.txt", "apt packages"),
+    ("locks/apt-sources.list", "apt snapshot"),
+    ("locks/python-bootstrap.txt", "python bootstrap lock"),
+    ("locks/python-build.txt", "python build lock"),
+    ("locks/python-runtime.txt", "python runtime lock"),
+]
+
+for lock_path, lock_label in lockfiles:
+    old_result = subprocess.run(
+        ["git", "show", f"{baseref}:{lock_path}"],
+        capture_output=True, text=True,
+    )
+    new_result = subprocess.run(
+        ["git", "show", f"HEAD:{lock_path}"],
+        capture_output=True, text=True,
+    )
+    if old_result.returncode == 0 and new_result.returncode == 0 and old_result.stdout and new_result.stdout:
+        old_hash = hashlib.sha256(old_result.stdout.encode()).hexdigest()[:12]
+        new_hash = hashlib.sha256(new_result.stdout.encode()).hexdigest()[:12]
+        if old_hash != new_hash:
+            # For apt-sources.list, show the snapshot date when it differs
+            if lock_path == "locks/apt-sources.list":
+                m_old = re.search(r"snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)", old_result.stdout)
+                m_new = re.search(r"snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)", new_result.stdout)
+                if m_old and m_new and m_old.group(1) != m_new.group(1):
+                    changes[f"LOCK:{lock_path}"] = (m_old.group(1), m_new.group(1))
+                else:
+                    changes[f"LOCK:{lock_path}"] = (f"sha256:{old_hash}", f"sha256:{new_hash}")
+            else:
+                changes[f"LOCK:{lock_path}"] = (f"sha256:{old_hash}", f"sha256:{new_hash}")
+
+# Separate component changes from lockfile changes
+lock_keys = {k for k in changes if k.startswith("LOCK:")}
+component_changes = {k: v for k, v in changes.items() if k not in lock_keys and k != "GB10_BUILD"}
+lock_changes = {k: v for k, v in changes.items() if k in lock_keys}
+
+# Format both via shared function
+change_lines = format_changes_with_lockfiles(component_changes, lock_changes, COMPONENT_LABELS)
+
+lines = ["### Changes in this PR", ""]
+if change_lines:
+    lines.extend(change_lines)
+else:
+    lines.append("- No component changes detected (unexpected)")
+
+body = "\n".join(lines) + "\n"
+print(body, end="")
+PYEOF

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -22,7 +22,20 @@ set -a; . ./versions.env; set +a
 SHORT_SHA="${GITHUB_SHA::7}"
 
 python3 - <<'PYEOF'
-import os, re, subprocess, textwrap
+import os, subprocess, textwrap, sys
+
+# Add scripts/ to sys.path so the shared module is importable
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__))))
+
+from versions_diff import (
+    COMPONENT_LABELS,
+    COMPONENTS,
+    LOCKFILES,
+    parse_versions_env,
+    file_sha256,
+    extract_apt_snapshot_date,
+    format_change_lines,
+)
 
 tag               = os.environ["TAG"]
 short_sha         = os.environ["GITHUB_SHA"][:7]
@@ -65,38 +78,6 @@ tag_sha        = f"{registry}:sha-{short_sha}"
 # ---------------------------------------------------------------------------
 # Determine previous tag and diff component versions
 # ---------------------------------------------------------------------------
-# Components to track for changes (variable name -> display label)
-COMPONENTS = [
-    ("VLLM_REF", "vLLM"),
-    ("FLASHINFER_REF", "FlashInfer"),
-    ("NCCL_REF", "NCCL"),
-    ("TORCH_VERSION", "PyTorch"),
-    ("TORCHVISION_VERSION", "torchvision"),
-    ("TORCHAUDIO_VERSION", "torchaudio"),
-    ("TRITON_VERSION", "Triton"),
-    ("CUDA_BASE_IMAGE", "CUDA base"),
-    ("UV_VERSION", "uv"),
-    ("RAY_VERSION", "Ray"),
-    ("NVSHMEM_VERSION", "NVSHMEM"),
-    ("TVM_FFI_VERSION", "TVM-FFI"),
-    ("TILELANG_VERSION", "TileLang"),
-    ("NUMBA_VERSION", "Numba"),
-    ("FASTSAFETENSORS_VERSION", "fastsafetensors"),
-    ("INSTANTTENSOR_VERSION", "instanttensor"),
-    ("TORCH_CUDA_ARCH_LIST", "Target arch"),
-]
-
-def parse_versions_env(text):
-    """Parse a versions.env text into a dict of variable -> value."""
-    env = {}
-    for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        m = re.match(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)$', line)
-        if m:
-            env[m.group(1)] = m.group(2)
-    return env
 
 def get_previous_tag(current_tag):
     """Find the previous v*-gb10.* tag before current_tag, sorted by version."""
@@ -136,11 +117,6 @@ def git_show_file(prev_tag, path):
     except Exception:
         return None
 
-def file_sha256(content):
-    """Return first 12 chars of SHA256 hex digest of content."""
-    import hashlib
-    return hashlib.sha256(content.encode()).hexdigest()[:12]
-
 def read_current_file(path):
     """Read a file from the working tree."""
     try:
@@ -149,34 +125,21 @@ def read_current_file(path):
     except Exception:
         return None
 
-def extract_apt_snapshot_date(content):
-    """Extract the snapshot timestamp from apt-sources.list, e.g. 20260714T000000Z."""
-    if not content:
-        return None
-    m = re.search(r'snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)', content)
-    return m.group(1) if m else None
-
 prev_tag = get_previous_tag(tag)
 changed_lines = []
 
 if prev_tag:
     prev_env = get_previous_versions(prev_tag)
     if prev_env:
+        changes = {}
         for var, label in COMPONENTS:
             old_val = prev_env.get(var, "")
             new_val = os.environ.get(var, "")
             if old_val != new_val:
-                changed_lines.append(f"- **{label}**: {old_val} -> {new_val}")
+                changes[var] = (old_val, new_val)
+        changed_lines = format_change_lines(changes, COMPONENT_LABELS)
 
     # --- Lockfile diffs ---
-    LOCKFILES = [
-        ("locks/apt-packages.txt", "apt packages"),
-        ("locks/apt-sources.list", "apt snapshot"),
-        ("locks/python-bootstrap.txt", "python bootstrap lock"),
-        ("locks/python-build.txt", "python build lock"),
-        ("locks/python-runtime.txt", "python runtime lock"),
-    ]
-
     for lock_path, lock_label in LOCKFILES:
         old_content = git_show_file(prev_tag, lock_path)
         new_content = read_current_file(lock_path)
@@ -184,7 +147,6 @@ if prev_tag:
             old_hash = file_sha256(old_content)
             new_hash = file_sha256(new_content)
             if old_hash != new_hash:
-                # For apt-sources.list, show the snapshot date change
                 if lock_path == "locks/apt-sources.list":
                     old_date = extract_apt_snapshot_date(old_content)
                     new_date = extract_apt_snapshot_date(new_content)

--- a/scripts/versions_diff.py
+++ b/scripts/versions_diff.py
@@ -1,0 +1,158 @@
+"""
+Shared logic for diffing versions.env across releases or working-tree changes.
+
+Provides the canonical mapping of version variable names to human-readable
+labels, and functions to produce markdown change lists from two env dicts.
+
+Used by:
+  - scripts/generate-release-notes.sh  (release notes)
+  - .github/workflows/monitor-upstream-releases.yaml  (automated PR body)
+  - tests/test-pr-body-generation.py  (test harness)
+"""
+
+import hashlib
+import re
+
+# Map variable names to human-readable labels.
+# This is the single source of truth for version display names.
+COMPONENT_LABELS = {
+    "VLLM_REF": "vLLM",
+    "FLASHINFER_REF": "FlashInfer",
+    "NCCL_REF": "NCCL",
+    "UV_VERSION": "uv",
+    "TORCH_VERSION": "PyTorch",
+    "TORCHVISION_VERSION": "torchvision",
+    "TORCHAUDIO_VERSION": "torchaudio",
+    "TRITON_VERSION": "Triton",
+    "NVSHMEM_VERSION": "NVSHMEM",
+    "TVM_FFI_VERSION": "TVM-FFI",
+    "TILELANG_VERSION": "TileLang",
+    "NUMBA_VERSION": "Numba",
+    "RAY_VERSION": "Ray",
+    "FASTSAFETENSORS_VERSION": "fastsafetensors",
+    "INSTANTTENSOR_VERSION": "instanttensor",
+    "CUDA_BASE_IMAGE": "CUDA base",
+    "CUDA_BASE_DIGEST": "CUDA base digest",
+    "BITSANDBYTES_VERSION": "bitsandbytes",
+    "ACCELERATE_VERSION": "Accelerate",
+    "TORCH_CUDA_ARCH_LIST": "Target arch",
+    "GB10_BUILD": "GB10_BUILD",
+}
+
+# Versions.env components (variable, label) list for release notes ordering.
+COMPONENTS = [(k, v) for k, v in COMPONENT_LABELS.items()
+              if k not in ("CUDA_BASE_DIGEST", "GB10_BUILD")]
+
+# Lockfile change tracking for release notes.
+LOCKFILES = [
+    ("locks/apt-packages.txt", "apt packages"),
+    ("locks/apt-sources.list", "apt snapshot"),
+    ("locks/python-bootstrap.txt", "python bootstrap lock"),
+    ("locks/python-build.txt", "python build lock"),
+    ("locks/python-runtime.txt", "python runtime lock"),
+]
+
+
+def parse_versions_env(text):
+    """Parse versions.env text into a dict of variable -> value."""
+    env = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line)
+        if m:
+            env[m.group(1)] = m.group(2)
+    return env
+
+
+def diff_env_dicts(old_env, new_env):
+    """Compare two env dicts and return {key: (old_val, new_val)} for changes."""
+    changes = {}
+    all_keys = set(old_env.keys()) | set(new_env.keys())
+    for key in sorted(all_keys):
+        old_val = old_env.get(key, "")
+        new_val = new_env.get(key, "")
+        if old_val != new_val:
+            changes[key] = (old_val, new_val)
+    return changes
+
+
+def diff_from_git_diff(diff_text):
+    """Parse a unified git diff text and return {key: (old_val, new_val)}.
+
+    Matches patterns like:
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+    """
+    changes = {}
+    for m in re.finditer(r"^-([A-Za-z_][A-Za-z0-9_]*)=(.*)", diff_text, re.MULTILINE):
+        key = m.group(1)
+        old_val = m.group(2)
+        plus_m = re.search(
+            r"^\+" + re.escape(key) + r"=(.*)", diff_text, re.MULTILINE
+        )
+        if plus_m:
+            new_val = plus_m.group(1)
+            if old_val != new_val:
+                changes[key] = (old_val, new_val)
+                continue
+        changes[key] = (old_val, "(removed)")
+    return changes
+
+
+def format_change_lines(changes, labels=None):
+    """Format a changes dict into a list of markdown bullet lines."""
+    if labels is None:
+        labels = COMPONENT_LABELS
+    lines = []
+    for key, (old_val, new_val) in sorted(changes.items()):
+        label = labels.get(key, key)
+        lines.append(f"- **{label}**: {old_val} -> {new_val}")
+    return lines
+
+
+def _format_lockfile_value(val):
+    """Apply backtick code styling to SHA256 hashes, leave other values plain."""
+    stripped = val.removeprefix("sha256:")
+    if stripped != val:
+        return f"`{stripped}`"
+    return val
+
+
+def format_changes_with_lockfiles(component_changes, lock_changes, labels=None):
+    """Format both component and lockfile changes into a single sorted list.
+
+    Separates known components (via format_change_lines) from lockfile changes
+    (with human-readable labels), then combines them in sorted order.
+    Lockfile values starting with 'sha256:' get backtick-styled (e.g. `` `abc123` ``).
+    Other values (snapshot dates, etc.) remain plain text.
+    """
+    if labels is None:
+        labels = COMPONENT_LABELS
+    change_lines = format_change_lines(component_changes, labels)
+
+    lock_labels = dict(LOCKFILES)
+    for key in sorted(lock_changes):
+        lock_path = key[5:]  # strip "LOCK:" prefix
+        old_val, new_val = lock_changes[key]
+        label = lock_labels.get(lock_path, lock_path)
+        change_lines.append(
+            f"- **{label}**: {_format_lockfile_value(old_val)}"
+            f" -> {_format_lockfile_value(new_val)}"
+        )
+
+    return change_lines
+
+
+def file_sha256(content):
+    """Return first 12 chars of SHA256 hex digest of content."""
+    return hashlib.sha256(content.encode()).hexdigest()[:12]
+
+
+def extract_apt_snapshot_date(content):
+    """Extract the snapshot timestamp from apt-sources.list, e.g. 20260714T000000Z."""
+    if not content:
+        return None
+    m = re.search(r"snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)", content)
+    return m.group(1) if m else None

--- a/tests/test-pr-body-generation.py
+++ b/tests/test-pr-body-generation.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""
+Tests for PR body generation (scripts/generate-pr-body.sh logic).
+
+Tests cover:
+  - diff_from_git_diff parsing
+  - format_changes_with_lockfiles output
+  - Lockfile change detection
+  - Apt snapshot date extraction
+  - Edge cases: empty diff, new/removed variables, comment lines,
+    commit SHA changes, multi-hunk diffs
+"""
+
+import hashlib
+import sys
+import textwrap
+
+sys.path.insert(0, "scripts")
+from versions_diff import (
+    COMPONENT_LABELS,
+    LOCKFILES,
+    diff_from_git_diff,
+    format_changes_with_lockfiles,
+    format_change_lines,
+    file_sha256,
+    extract_apt_snapshot_date,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+def build_body(component_changes, lock_changes=None):
+    """Build the full PR body markdown (mirrors generate-pr-body.sh logic)."""
+    if lock_changes is None:
+        lock_changes = {}
+    change_lines = format_changes_with_lockfiles(
+        component_changes, lock_changes, COMPONENT_LABELS
+    )
+    lines = ["### Changes in this PR", ""]
+    if change_lines:
+        lines.extend(change_lines)
+    else:
+        lines.append("- No component changes detected (unexpected)")
+    return "\n".join(lines) + "\n"
+
+
+# Shortcut: parse diff text and build body in one step
+def body_from_diff(diff_text, lock_changes=None):
+    changes = diff_from_git_diff(diff_text)
+    # Filter out GB10_BUILD (same as generate-pr-body.sh does)
+    component_changes = {k: v for k, v in changes.items() if k != "GB10_BUILD"}
+    return build_body(component_changes, lock_changes)
+
+
+def body_body(body):
+    """Extract the change lines (after '### Changes in this PR') from a body."""
+    lines = body.splitlines()
+    try:
+        idx = lines.index("### Changes in this PR")
+    except ValueError:
+        return []
+    rest = lines[idx + 1:]
+    # Skip blank line after header
+    if rest and rest[0] == "":
+        rest = rest[1:]
+    return [l for l in rest if l]
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+SCENARIOS = [
+    # (name, diff_text, lock_changes, expected_change_count, expected_body_lines)
+    (
+        "Single component update (vLLM only)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        """),
+        {},
+        1,
+        ["- **vLLM**: v0.24.0 -> v0.25.1"],
+    ),
+    (
+        "Multiple component updates",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        -NCCL_REF=v2.30.4-1
+        +NCCL_REF=v2.30.5-1
+        -FLASHINFER_REF=v0.6.12
+        +FLASHINFER_REF=v0.6.13
+        -TORCH_VERSION=2.10.0
+        +TORCH_VERSION=2.11.0
+        -RAY_VERSION=2.55.0
+        +RAY_VERSION=2.56.0
+        """),
+        {},
+        6,
+        [
+            "- **FlashInfer**: v0.6.12 -> v0.6.13",
+            "- **NCCL**: v2.30.4-1 -> v2.30.5-1",
+            "- **Ray**: 2.55.0 -> 2.56.0",
+            "- **PyTorch**: 2.10.0 -> 2.11.0",
+            "- **uv**: 0.11.29 -> 0.11.30",
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "CUDA base with slashes in value + GB10_BUILD (GB10_BUILD filtered)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -CUDA_BASE_IMAGE=nvidia/cuda:13.2.0-devel-ubuntu24.04
+        +CUDA_BASE_IMAGE=nvidia/cuda:13.3.0-devel-ubuntu24.04
+        -GB10_BUILD=1
+        +GB10_BUILD=2
+        """),
+        {},
+        1,
+        [
+            "- **CUDA base**: nvidia/cuda:13.2.0-devel-ubuntu24.04"
+            " -> nvidia/cuda:13.3.0-devel-ubuntu24.04",
+        ],
+    ),
+    (
+        "UV version bump only",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        """),
+        {},
+        1,
+        ["- **uv**: 0.11.29 -> 0.11.30"],
+    ),
+    (
+        "No changes (empty diff, no lock changes)",
+        "",
+        {},
+        1,
+        ["- No component changes detected (unexpected)"],
+    ),
+    (
+        "GB10_BUILD increment alongside vLLM ref change",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.25.0
+        +VLLM_REF=v0.25.1
+        -GB10_BUILD=5
+        +GB10_BUILD=6
+        """),
+        {},
+        1,
+        [
+            "- **vLLM**: v0.25.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "FlashInfer mismatch correction matching vLLM pin",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -FLASHINFER_REF=v0.6.12
+        +FLASHINFER_REF=v0.6.13
+        """),
+        {},
+        1,
+        ["- **FlashInfer**: v0.6.12 -> v0.6.13"],
+    ),
+    (
+        "PyTorch, torchvision, torchaudio all bump together",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -TORCH_VERSION=2.10.0
+        +TORCH_VERSION=2.11.0
+        -TORCHVISION_VERSION=0.25.0
+        +TORCHVISION_VERSION=0.26.0
+        -TORCHAUDIO_VERSION=2.10.0
+        +TORCHAUDIO_VERSION=2.11.0
+        """),
+        {},
+        3,
+        [
+            "- **torchaudio**: 2.10.0 -> 2.11.0",
+            "- **torchvision**: 0.25.0 -> 0.26.0",
+            "- **PyTorch**: 2.10.0 -> 2.11.0",
+        ],
+    ),
+    (
+        "Unknown variable name in diff uses key as label",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -SOME_NEW_VAR=old
+        +SOME_NEW_VAR=new
+        """),
+        {},
+        1,
+        ["- **SOME_NEW_VAR**: old -> new"],
+    ),
+    (
+        "Variable removed entirely (no + counterpart) includes removed entry",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -OBSOLETE_VAR=old_value
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        """),
+        {},
+        2,
+        [
+            "- **OBSOLETE_VAR**: old_value -> (removed)",
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "Variable added entirely (no - counterpart)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        +BRAND_NEW_VAR=1.0.0
+        """),
+        {},
+        1,
+        [
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "URL with slashes in value (PYTORCH_INDEX_URL change)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu130
+        +PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu131
+        """),
+        {},
+        1,
+        [
+            "- **PYTORCH_INDEX_URL**: "
+            "https://download.pytorch.org/whl/cu130 -> "
+            "https://download.pytorch.org/whl/cu131"
+        ],
+    ),
+    (
+        "Comment lines in diff are ignored",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,7 +1,7 @@
+        -# This is a comment line
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        -# Another comment that changed
+        +# Another comment that changed (updated)
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        """),
+        {},
+        2,
+        [
+            "- **uv**: 0.11.29 -> 0.11.30",
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "Commit SHA changes with ref changes (bump.sh resolved commit)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -NCCL_COMMIT=73cf112295c33aee2b895f329f592f2a9b4b0f97
+        +NCCL_COMMIT=aabbccddee1234567890abcdef1234567890abcd
+        -VLLM_REF=v0.25.1
+        +VLLM_REF=v0.26.0
+        -VLLM_COMMIT=752a3a504485790a2e8491cacbb35c137339ad34
+        +VLLM_COMMIT=ffee1234567890abcdef1234567890abcdef1234
+        -FLASHINFER_COMMIT=57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac
+        +FLASHINFER_COMMIT=bbbbccccddddeeee1234567890abcdef12345678
+        """),
+        {},
+        4,
+        [
+            "- **FLASHINFER_COMMIT**: "
+            "57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac -> "
+            "bbbbccccddddeeee1234567890abcdef12345678",
+            "- **NCCL_COMMIT**: "
+            "73cf112295c33aee2b895f329f592f2a9b4b0f97 -> "
+            "aabbccddee1234567890abcdef1234567890abcd",
+            "- **VLLM_COMMIT**: "
+            "752a3a504485790a2e8491cacbb35c137339ad34 -> "
+            "ffee1234567890abcdef1234567890abcdef1234",
+            "- **vLLM**: v0.25.1 -> v0.26.0",
+        ],
+    ),
+    (
+        "Diff across multiple hunks",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        @@ -10,14 +10,14 @@
+        -RAY_VERSION=2.55.0
+        +RAY_VERSION=2.56.0
+        """),
+        {},
+        2,
+        [
+            "- **Ray**: 2.55.0 -> 2.56.0",
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+    (
+        "Only commit SHAs change, refs stay same (rebuild only)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -NCCL_COMMIT=73cf112295c33aee2b895f329f592f2a9b4b0f97
+        +NCCL_COMMIT=newsha111111111111111111111111111111111111
+        -VLLM_COMMIT=752a3a504485790a2e8491cacbb35c137339ad34
+        +VLLM_COMMIT=newsha222222222222222222222222222222222222
+        -FLASHINFER_COMMIT=57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac
+        +FLASHINFER_COMMIT=newsha3333333333333333333333333333333333
+        """),
+        {},
+        3,
+        [
+            "- **FLASHINFER_COMMIT**: "
+            "57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac -> "
+            "newsha3333333333333333333333333333333333",
+            "- **NCCL_COMMIT**: "
+            "73cf112295c33aee2b895f329f592f2a9b4b0f97 -> "
+            "newsha111111111111111111111111111111111111",
+            "- **VLLM_COMMIT**: "
+            "752a3a504485790a2e8491cacbb35c137339ad34 -> "
+            "newsha222222222222222222222222222222222222",
+        ],
+    ),
+    (
+        "Version bump + lockfile changes together (uv + all lockfiles)",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        """),
+        {
+            "LOCK:locks/python-bootstrap.txt": (
+                "sha256:e6d414e1c17a",
+                "sha256:e5031a741513",
+            ),
+            "LOCK:locks/python-build.txt": (
+                "sha256:77f8a45e76ba",
+                "sha256:6a2812bb292d",
+            ),
+            "LOCK:locks/python-runtime.txt": (
+                "sha256:91eda20c8c46",
+                "sha256:5fc181aa35a8",
+            ),
+        },
+        4,
+        [
+            "- **uv**: 0.11.29 -> 0.11.30",
+            "- **python bootstrap lock**: "
+            "`e6d414e1c17a` -> `e5031a741513`",
+            "- **python build lock**: "
+            "`77f8a45e76ba` -> `6a2812bb292d`",
+            "- **python runtime lock**: "
+            "`91eda20c8c46` -> `5fc181aa35a8`",
+        ],
+    ),
+    (
+        "Apt snapshot date change in lockfiles",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        """),
+        {
+            "LOCK:locks/apt-sources.list": (
+                "20260601T000000Z",
+                "20260714T000000Z",
+            ),
+        },
+        2,
+        [
+            "- **uv**: 0.11.29 -> 0.11.30",
+            "- **apt snapshot**: 20260601T000000Z -> 20260714T000000Z",
+        ],
+    ),
+    (
+        "Lockfiles only, no versions.env changes",
+        "",
+        {
+            "LOCK:locks/apt-packages.txt": (
+                "sha256:aaaa11111111",
+                "sha256:bbbb22222222",
+            ),
+            "LOCK:locks/python-bootstrap.txt": (
+                "sha256:cccc33333333",
+                "sha256:dddd44444444",
+            ),
+        },
+        2,
+        [
+            "- **apt packages**: "
+            "`aaaa11111111` -> `bbbb22222222`",
+            "- **python bootstrap lock**: "
+            "`cccc33333333` -> `dddd44444444`",
+        ],
+    ),
+    (
+        "Apt snapshot same date but content hash differs",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        """),
+        {
+            "LOCK:locks/apt-sources.list": (
+                "sha256:aaaa11111111",
+                "sha256:bbbb22222222",
+            ),
+        },
+        2,
+        [
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+            "- **apt snapshot**: "
+            "`aaaa11111111` -> `bbbb22222222`",
+        ],
+    ),
+    (
+        "Version bump + apt snapshot date + lockfile hash changes",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -TORCH_VERSION=2.10.0
+        +TORCH_VERSION=2.11.0
+        """),
+        {
+            "LOCK:locks/apt-sources.list": (
+                "20260601T000000Z",
+                "20260714T000000Z",
+            ),
+            "LOCK:locks/python-runtime.txt": (
+                "sha256:aaa111",
+                "sha256:bbb222",
+            ),
+        },
+        3,
+        [
+            "- **PyTorch**: 2.10.0 -> 2.11.0",
+            "- **apt snapshot**: 20260601T000000Z -> 20260714T000000Z",
+            "- **python runtime lock**: "
+            "`aaa111` -> `bbb222`",
+        ],
+    ),
+    (
+        "Unknown lockfile path uses path as fallback label",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        """),
+        {
+            "LOCK:locks/some-new-lock.txt": (
+                "sha256:aaaa11111111",
+                "sha256:bbbb22222222",
+            ),
+        },
+        2,
+        [
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+            "- **locks/some-new-lock.txt**: "
+            "`aaaa11111111` -> `bbbb22222222`",
+        ],
+    ),
+    (
+        "Lockfile value without sha256: prefix left as-is",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        """),
+        {
+            "LOCK:locks/custom-tag.txt": (
+                "v1.0",
+                "v2.0",
+            ),
+        },
+        2,
+        [
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+            "- **locks/custom-tag.txt**: v1.0 -> v2.0",
+        ],
+    ),
+    (
+        "All known components change at once -- smoke test",
+        textwrap.dedent("""\
+        diff --git a/versions.env b/versions.env
+        index abc..def 100644
+        --- a/versions.env
+        +++ b/versions.env
+        @@ -1,5 +1,5 @@
+        -VLLM_REF=v0.24.0
+        +VLLM_REF=v0.25.1
+        -FLASHINFER_REF=v0.6.12
+        +FLASHINFER_REF=v0.6.13
+        -NCCL_REF=v2.30.4-1
+        +NCCL_REF=v2.30.5-1
+        -UV_VERSION=0.11.29
+        +UV_VERSION=0.11.30
+        -TORCH_VERSION=2.10.0
+        +TORCH_VERSION=2.11.0
+        -TORCHVISION_VERSION=0.25.0
+        +TORCHVISION_VERSION=0.26.0
+        -TORCHAUDIO_VERSION=2.10.0
+        +TORCHAUDIO_VERSION=2.11.0
+        -TRITON_VERSION=3.5.0
+        +TRITON_VERSION=3.6.0
+        -NVSHMEM_VERSION=3.4.0
+        +NVSHMEM_VERSION=3.4.5
+        -TVM_FFI_VERSION=0.1.8
+        +TVM_FFI_VERSION=0.1.9
+        -TILELANG_VERSION=0.1.8
+        +TILELANG_VERSION=0.1.9
+        -NUMBA_VERSION=0.64.0
+        +NUMBA_VERSION=0.65.0
+        -RAY_VERSION=2.55.0
+        +RAY_VERSION=2.56.0
+        -FASTSAFETENSORS_VERSION=0.2.1
+        +FASTSAFETENSORS_VERSION=0.2.2
+        -INSTANTTENSOR_VERSION=0.1.7
+        +INSTANTTENSOR_VERSION=0.1.8
+        -CUDA_BASE_IMAGE=nvidia/cuda:13.2.0-devel-ubuntu24.04
+        +CUDA_BASE_IMAGE=nvidia/cuda:13.3.0-devel-ubuntu24.04
+        -BITSANDBYTES_VERSION=0.48.0
+        +BITSANDBYTES_VERSION=0.49.2
+        -ACCELERATE_VERSION=1.13.0
+        +ACCELERATE_VERSION=1.14.0
+        """),
+        {},
+        18,
+        [
+            "- **Accelerate**: 1.13.0 -> 1.14.0",
+            "- **bitsandbytes**: 0.48.0 -> 0.49.2",
+            "- **CUDA base**: nvidia/cuda:13.2.0-devel-ubuntu24.04"
+            " -> nvidia/cuda:13.3.0-devel-ubuntu24.04",
+            "- **fastsafetensors**: 0.2.1 -> 0.2.2",
+            "- **FlashInfer**: v0.6.12 -> v0.6.13",
+            "- **instanttensor**: 0.1.7 -> 0.1.8",
+            "- **NCCL**: v2.30.4-1 -> v2.30.5-1",
+            "- **Numba**: 0.64.0 -> 0.65.0",
+            "- **NVSHMEM**: 3.4.0 -> 3.4.5",
+            "- **Ray**: 2.55.0 -> 2.56.0",
+            "- **TileLang**: 0.1.8 -> 0.1.9",
+            "- **torchaudio**: 2.10.0 -> 2.11.0",
+            "- **torchvision**: 0.25.0 -> 0.26.0",
+            "- **PyTorch**: 2.10.0 -> 2.11.0",
+            "- **Triton**: 3.5.0 -> 3.6.0",
+            "- **TVM-FFI**: 0.1.8 -> 0.1.9",
+            "- **uv**: 0.11.29 -> 0.11.30",
+            "- **vLLM**: v0.24.0 -> v0.25.1",
+        ],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+passed = 0
+failed = 0
+
+
+def check(condition, message):
+    global passed, failed
+    if condition:
+        passed += 1
+    else:
+        failed += 1
+        print(f"  FAIL: {message}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Run scenario tests
+# ---------------------------------------------------------------------------
+
+for name, diff_text, lock_changes, expected_count, expected_lines in SCENARIOS:
+    print(f"Scenario: {name}")
+    try:
+        body = body_from_diff(diff_text, lock_changes)
+        body_lines = body_body(body)
+
+        actual_count = len(body_lines)
+        check(
+            actual_count == expected_count,
+            f"Expected {expected_count} change lines, got {actual_count}",
+        )
+
+        for i, expected in enumerate(expected_lines):
+            if i < len(body_lines):
+                check(
+                    body_lines[i] == expected,
+                    f"Line {i}: expected {expected!r}, got {body_lines[i]!r}",
+                )
+            else:
+                check(False, f"Missing line {i}: {expected!r}")
+
+        print(f"  Body lines ({actual_count}):")
+        for line in body_lines:
+            print(f"    {line}")
+    except Exception as e:
+        failed += 1
+        print(f"  EXCEPTION: {e}", file=sys.stderr)
+    print()
+
+
+# Additional unit tests for utility functions
+print("Unit tests: file_sha256")
+h = file_sha256("hello")
+check(len(h) == 12, f"Expected 12 chars, got {len(h)}: {h}")
+check(h == hashlib.sha256(b"hello").hexdigest()[:12], "SHA256 mismatch")
+
+print()
+print("Unit tests: _format_lockfile_value")
+# Import the private helper directly
+from versions_diff import _format_lockfile_value
+check(
+    _format_lockfile_value("sha256:abc123def456") == "`abc123def456`",
+    f"sha256 prefix: {_format_lockfile_value('sha256:abc123def456')!r}",
+)
+check(
+    _format_lockfile_value("20260601T000000Z") == "20260601T000000Z",
+    f"date: {_format_lockfile_value('20260601T000000Z')!r}",
+)
+check(
+    _format_lockfile_value("v1.0") == "v1.0",
+    f"plain tag: {_format_lockfile_value('v1.0')!r}",
+)
+check(
+    _format_lockfile_value("") == "",
+    f"empty: {_format_lockfile_value('')!r}",
+)
+# Value containing sha256: but not as prefix should not be stripped
+check(
+    _format_lockfile_value("foo sha256:bar") == "foo sha256:bar",
+    f"embedded sha256: {_format_lockfile_value('foo sha256:bar')!r}",
+)
+
+print()
+print("Unit tests: extract_apt_snapshot_date")
+content = textwrap.dedent("""\
+    deb https://snapshot.ubuntu.com/ubuntu/20260601T000000Z/ noble main
+    deb https://snapshot.ubuntu.com/ubuntu/20260601T000000Z/ noble-updates main
+""")
+d = extract_apt_snapshot_date(content)
+check(d == "20260601T000000Z", f"Expected 20260601T000000Z, got {d!r}")
+
+d2 = extract_apt_snapshot_date("no match here")
+check(d2 is None, f"Expected None, got {d2!r}")
+
+d3 = extract_apt_snapshot_date("")
+check(d3 is None, f"Expected None for empty, got {d3!r}")
+
+print()
+print()
+if failed:
+    print(f"FAILED: {failed} of {passed + failed} checks failed")
+    sys.exit(1)
+else:
+    print(f"All {passed} checks passed!")
+    sys.exit(0)


### PR DESCRIPTION
Replace the static PR body placeholder with dynamically generated content that lists what actually changed.

- Extracts shared component labels, lockfile definitions, env parsing, and diff formatting into `scripts/versions_diff.py` -- single source of truth used by both release notes and PR body generation
- Creates `scripts/generate-pr-body.sh` for CI use, wrapping the shared module with git-based lockfile SHA tracking
- Replaces static body string in `monitor-upstream-releases.yaml` with `body-path:` pointing to the generated output
- Updates `scripts/generate-release-notes.sh` to import from the shared module instead of duplicating all the logic
- Adds test harness with 21 scenarios covering version bumps, lockfile changes, apt snapshot dates, commit SHA noise, `GB10_BUILD` filtering, and edge cases
- Lockfile hashes display with backtick code styling (e.g. `` `e6d414e1c17a` -> `e5031a741513` ``)
- Apt snapshot dates displayed as plain text