### PR TITLE
feat(pr-body): extract check-duplicate-pr.py script with tests and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: thursday
       time: "09:00"
       timezone: "America/Chicago"
     labels:

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -63,13 +63,24 @@ jobs:
             echo "has-changes=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build PR body
-        id: pr-body
+      - name: Check for existing PR with same changes
+        id: existing-pr
         if: steps.changes.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_MONITOR_PAT }}
+        run: |
+          if scripts/check-duplicate-pr.py; then
+            echo "skip-pr=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip-pr=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        if: steps.changes.outputs.has-changes == 'true' && steps.existing-pr.outputs.skip-pr == 'false'
         run: scripts/generate-pr-body.sh > /tmp/pr-body.md
 
       - name: Create Pull Request
-        if: steps.changes.outputs.has-changes == 'true'
+        if: steps.changes.outputs.has-changes == 'true' && steps.existing-pr.outputs.skip-pr == 'false'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.RELEASE_MONITOR_PAT }}

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -18,6 +18,8 @@ on:
       - scripts/generate-release-notes.sh
       - tests/test-release-notes-scenarios.py
       - tests/test-pr-body-generation.py
+      - tests/test-check-duplicate-pr.py
+      - scripts/check-duplicate-pr.py
       - .github/workflows/monitor-upstream-releases.yaml
   workflow_dispatch:
 
@@ -41,6 +43,9 @@ jobs:
 
       - name: Run PR body generation test harness
         run: python3 tests/test-pr-body-generation.py
+
+      - name: Run duplicate PR check test harness
+        run: python3 tests/test-check-duplicate-pr.py
 
       - name: Verify output is well-formed
         run: |

--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Check if an open deps/bump PR already exists with identical versions.env changes.
+
+Returns exit code 0 (skip) or 1 (proceed) and prints a user-facing message.
+
+Usage:
+  scripts/check-duplicate-pr.py
+
+Environment:
+  GH_TOKEN: GitHub token for gh CLI authentication
+
+Exit codes:
+  0 - Skip: an existing open PR already has the same versions.env changes
+      (or no changes to versions.env in working tree)
+  1 - Proceed: no matching PR found, caller should create a new one
+"""
+
+import json
+import subprocess
+import sys
+
+
+def run_git(args, check=True):
+    """Run a git command and return the result."""
+    return subprocess.run(
+        ["git"] + args,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def run_gh(args, check=True):
+    """Run a gh command and return the result."""
+    return subprocess.run(
+        ["gh"] + args,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def check_for_duplicate():
+    """Check for existing PRs with matching versions.env, return True if duplicate."""
+    # First check if versions.env actually has uncommitted changes
+    diff_result = run_git(
+        ["diff", "--exit-code", "versions.env"], check=False
+    )
+    if diff_result.returncode == 0:
+        # No changes to versions.env in working tree -- nothing to PR
+        print("No changes to versions.env in working tree")
+        return True
+
+    # Find all open deps/bump PRs by this actor
+    result = run_gh(
+        [
+            "pr", "list",
+            "--state", "OPEN",
+            "--author", "@me",
+            "--search", "deps/bump",
+            "--json", "number,headRefName",
+            "--jq", ".[]",
+        ],
+        check=False,
+    )
+    prs_text = result.stdout.strip()
+    if not prs_text:
+        print("No open deps/bump PRs by this actor")
+        return False
+
+    prs = json.loads(prs_text)
+    if not isinstance(prs, list):
+        prs = [prs]
+
+    for pr in prs:
+        number = pr["number"]
+        branch = pr["headRefName"]
+        print(f"Checking PR #{number} ({branch})...")
+
+        # Fetch the branch
+        run_git(["fetch", "origin", branch])
+
+        # Compare versions.env between the PR branch and the working tree
+        r = run_git(
+            ["diff", "--exit-code", f"origin/{branch}", "--", "versions.env"],
+            check=False,
+        )
+        if r.returncode == 0:
+            print(f"PR #{number} has matching versions.env -- skipping duplicate")
+            return True
+        else:
+            print(f"PR #{number} has different versions.env -- not a match")
+
+    print("No matching PR found -- will create new one")
+    return False
+
+
+if __name__ == "__main__":
+    should_skip = check_for_duplicate()
+    sys.exit(0 if should_skip else 1)

--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -41,15 +41,44 @@ def run_gh(args, check=True):
     )
 
 
+def get_versions_diff(ref=None):
+    """Get the diff for versions.env, optionally against a ref.
+
+    Returns the diff text, or None if there's no diff.
+    """
+    if ref:
+        args = ["diff", "--exit-code", f"origin/{ref}", "--", "versions.env"]
+    else:
+        # Check both staged and unstaged changes vs HEAD
+        args = ["diff", "--exit-code", "HEAD", "--", "versions.env"]
+    result = run_git(args, check=False)
+    if result.returncode == 0:
+        return None
+    return result.stdout
+
+
+def diff_has_substantive_changes(diff_text):
+    """Check if a versions.env diff has changes beyond GB10_BUILD.
+
+    Returns True if there are any changed variables other than GB10_BUILD.
+    """
+    if diff_text is None:
+        return False
+    for line in diff_text.splitlines():
+        # Look for +/- lines that define variables (not diff headers, not comments)
+        if line.startswith(("+", "-")) and "=" in line and not line.startswith("---") and not line.startswith("+++"):
+            var_name = line.split("=", 1)[0][1:].strip()  # strip +/- prefix
+            if var_name != "GB10_BUILD":
+                return True
+    return False
+
+
 def check_for_duplicate():
     """Check for existing PRs with matching versions.env, return True if duplicate."""
     # First check if versions.env actually has uncommitted changes
-    diff_result = run_git(
-        ["diff", "--exit-code", "versions.env"], check=False
-    )
-    if diff_result.returncode == 0:
-        # No changes to versions.env in working tree -- nothing to PR
-        print("No changes to versions.env in working tree")
+    working_diff = get_versions_diff()
+    if not diff_has_substantive_changes(working_diff):
+        print("No substantive changes to versions.env in working tree")
         return True
 
     # Find all open deps/bump PRs by this actor
@@ -69,9 +98,16 @@ def check_for_duplicate():
         print("No open deps/bump PRs by this actor")
         return False
 
-    prs = json.loads(prs_text)
-    if not isinstance(prs, list):
-        prs = [prs]
+    # gh --jq '.[]' outputs one JSON object per line (NDJSON) when there are
+    # multiple results, or a single JSON object when there's exactly one.
+    # Handle both cases.
+    lines = [l.strip() for l in prs_text.splitlines() if l.strip()]
+    if len(lines) == 1:
+        prs = json.loads(lines[0])
+        if not isinstance(prs, list):
+            prs = [prs]
+    else:
+        prs = [json.loads(line) for line in lines]
 
     for pr in prs:
         number = pr["number"]
@@ -81,12 +117,29 @@ def check_for_duplicate():
         # Fetch the branch
         run_git(["fetch", "origin", branch])
 
-        # Compare versions.env between the PR branch and the working tree
-        r = run_git(
-            ["diff", "--exit-code", f"origin/{branch}", "--", "versions.env"],
-            check=False,
-        )
-        if r.returncode == 0:
+        # Compare only the substantive portion of versions.env
+        branch_diff = get_versions_diff(branch)
+        if branch_diff is None:
+            # Branch versions.env matches working tree exactly (no diff)
+            print(f"PR #{number} has matching versions.env -- skipping duplicate")
+            return True
+
+        # Branch has a diff -- compare substantive lines
+        if diff_has_substantive_changes(branch_diff) != diff_has_substantive_changes(working_diff):
+            print(f"PR #{number} has different versions.env -- not a match")
+            continue
+
+        # Both diffs have substantive changes; compare the actual lines
+        def substantive_lines(diff):
+            lines = set()
+            for line in diff.splitlines():
+                if line.startswith(("+", "-")) and "=" in line and not line.startswith("---") and not line.startswith("+++"):
+                    var_name = line.split("=", 1)[0][1:].strip()
+                    if var_name != "GB10_BUILD":
+                        lines.add(line)
+            return lines
+
+        if substantive_lines(branch_diff) == substantive_lines(working_diff):
             print(f"PR #{number} has matching versions.env -- skipping duplicate")
             return True
         else:

--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -41,13 +41,18 @@ def run_gh(args, check=True):
     )
 
 
-def get_versions_diff(ref=None):
-    """Get the diff for versions.env, optionally against a ref.
+def get_versions_diff(ref=None, base=None):
+    """Get the diff for versions.env, optionally against a ref and/or base.
 
+    If ref is given, compares ref vs base (defaults to HEAD if no base).
+    If no ref, compares working tree vs HEAD.
     Returns the diff text, or None if there's no diff.
     """
     if ref:
-        args = ["diff", "--exit-code", f"origin/{ref}", "--", "versions.env"]
+        if base:
+            args = ["diff", "--exit-code", base, f"origin/{ref}", "--", "versions.env"]
+        else:
+            args = ["diff", "--exit-code", "HEAD", f"origin/{ref}", "--", "versions.env"]
     else:
         # Check both staged and unstaged changes vs HEAD
         args = ["diff", "--exit-code", "HEAD", "--", "versions.env"]
@@ -117,19 +122,14 @@ def check_for_duplicate():
         # Fetch the branch
         run_git(["fetch", "origin", branch])
 
-        # Compare only the substantive portion of versions.env
-        branch_diff = get_versions_diff(branch)
-        if branch_diff is None:
-            # Branch versions.env matches working tree exactly (no diff)
-            print(f"PR #{number} has matching versions.env -- skipping duplicate")
-            return True
-
-        # Branch has a diff -- compare substantive lines
-        if diff_has_substantive_changes(branch_diff) != diff_has_substantive_changes(working_diff):
+        # Compare the substantive changes between the PR branch and origin/main
+        # vs the working tree and origin/main. This way we compare what each
+        # changes relative to the common base, ignoring GB10_BUILD.
+        branch_diff_vs_main = get_versions_diff(branch, "origin/main")
+        if diff_has_substantive_changes(branch_diff_vs_main) != diff_has_substantive_changes(working_diff):
             print(f"PR #{number} has different versions.env -- not a match")
             continue
 
-        # Both diffs have substantive changes; compare the actual lines
         def substantive_lines(diff):
             lines = set()
             for line in diff.splitlines():
@@ -139,7 +139,7 @@ def check_for_duplicate():
                         lines.add(line)
             return lines
 
-        if substantive_lines(branch_diff) == substantive_lines(working_diff):
+        if substantive_lines(branch_diff_vs_main) == substantive_lines(working_diff):
             print(f"PR #{number} has matching versions.env -- skipping duplicate")
             return True
         else:

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -9,8 +9,8 @@ Scenario coverage:
   - Only GB10_BUILD changes (skip - not substantive)
   - Substantive changes, no open PRs (proceed)
   - Single PR with matching substantive changes (skip)
-  - Single PR with different substantive changes (proceed)
   - Single PR with only GB10_BUILD diff, working tree has UV (proceed - different substantive)
+  - Single PR with different substantive changes (proceed)
   - Single PR with same UV but different GB10_BUILD (skip - same substantive, GB10 ignored)
   - Multiple PRs, none matching (proceed)
   - Multiple PRs, second one matches (skip)
@@ -19,12 +19,11 @@ Scenario coverage:
   - gh pr list errors/network issue (proceed - fails open)
   - gh returns empty array (proceed)
   - git fetch fails (proceed - fetch failure shouldn't block)
-  - Branch has no substantive changes but working tree does (proceed)
-  - Working tree has only GB10_BUILD, branch has substantive (skip - no substantive changes)
+  - Branch has only GB10_BUILD change vs main, working tree has UV (proceed)
+  - Working tree has only GB10_BUILD, branch has substantive vs main (skip)
 """
 
 import sys
-import textwrap
 
 sys.path.insert(0, "scripts")
 
@@ -33,14 +32,12 @@ sys.path.insert(0, "scripts")
 # Helpers to generate realistic unified diff output for mock git
 # ---------------------------------------------------------------------------
 
-SIMPLE_DIFF = """\
+SIMPLE_UV_DIFF = """\
 diff --git a/versions.env b/versions.env
 index abc1234..def5678 100644
 --- a/versions.env
 +++ b/versions.env
 @@ -20,6 +20,6 @@ GB10_BUILD=2
- # Python / uv bootstrap
- # ---------------------------------------------------------------------------
 -UV_VERSION=0.11.29
 +UV_VERSION=0.11.30
 """
@@ -52,9 +49,6 @@ index abc1234..def5678 100644
 --- a/versions.env
 +++ b/versions.env
 @@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
- # Image stack revision.
- # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
- # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
 -GB10_BUILD=2
 +GB10_BUILD=3
 """
@@ -66,14 +60,9 @@ index abc1234..def5678 100644
 --- a/versions.env
 +++ b/versions.env
 @@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
- # Image stack revision.
- # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
- # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
 -GB10_BUILD=2
 +GB10_BUILD=3
 @@ -20,6 +20,6 @@ GB10_BUILD=3
- # Python / uv bootstrap
- # ---------------------------------------------------------------------------
 -UV_VERSION=0.11.29
 +UV_VERSION=0.11.30
 """
@@ -85,8 +74,6 @@ index abc1234..def5678 100644
 --- a/versions.env
 +++ b/versions.env
 @@ -28,6 +28,6 @@ GB10_BUILD=2
- # vLLM
- # ---------------------------------------------------------------------------
 -VLLM_REF=v0.24.0
 +VLLM_REF=v0.25.1
 """
@@ -98,14 +85,9 @@ index abc1234..def5678 100644
 --- a/versions.env
 +++ b/versions.env
 @@ -28,6 +28,6 @@ GB10_BUILD=2
- # vLLM
- # ---------------------------------------------------------------------------
 -VLLM_REF=v0.24.0
 +VLLM_REF=v0.25.1
 @@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
- # Image stack revision.
- # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
- # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
 -GB10_BUILD=2
 +GB10_BUILD=3
 """
@@ -132,135 +114,132 @@ if __name__ == "__main__":
     #
     # fake_gh_stdout: what gh pr list returns (empty string = no PRs, or error)
     # fake_git_behaviors dict:
-    #   working_diff: the diff text to return for working tree diff, or None for exit 0
-    #   branch_diffs: dict mapping branch name -> diff text, or None for exit 0
+    #   working_diff: the diff text to return for working tree diff vs HEAD, or None for exit 0
+    #   branch_diffs_vs_main: dict mapping branch name -> diff text vs origin/main, or None for exit 0
     #   fetch_exit: exit code for git fetch (0 = success, 1 = failure)
 
-    GB10_ONLY_BRANCH = GB10_ONLY_DIFF
-    UV_AND_GB10_BRANCH = UV_AND_GB10_DIFF
-    VLLM_AND_GB10_BRANCH = VLLM_AND_GB10_DIFF
     EMPTY = None  # No diff (exit 0)
 
     scenarios = [
         (
-            "No changes in working tree (git diff versions.env exits 0)",
+            "No changes in working tree",
             "",
-            {"working_diff": EMPTY, "branch_diffs": {}, "fetch_exit": 0},
+            {"working_diff": EMPTY, "branch_diffs_vs_main": {}, "fetch_exit": 0},
             0,  # skip (no changes)
         ),
         (
             "Only GB10_BUILD changes in working tree (not substantive)",
             "",
-            {"working_diff": GB10_ONLY_BRANCH, "branch_diffs": {}, "fetch_exit": 0},
+            {"working_diff": GB10_ONLY_DIFF, "branch_diffs_vs_main": {}, "fetch_exit": 0},
             0,  # skip (no substantive changes)
         ),
         (
             "Substantive changes (UV_VERSION + GB10_BUILD), no open PRs",
             "",
-            {"working_diff": UV_AND_GB10_BRANCH, "branch_diffs": {}, "fetch_exit": 0},
+            {"working_diff": UV_AND_GB10_DIFF, "branch_diffs_vs_main": {}, "fetch_exit": 0},
             1,  # proceed
         ),
         (
             "Single PR with matching substantive changes (UV_VERSION + GB10_BUILD)",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": None},  # exit 0 = same as working tree
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": UV_AND_GB10_DIFF},
              "fetch_exit": 0},
             0,  # skip
         ),
         (
-            "Single PR with only GB10_BUILD diff, working tree has UV (different substantive)",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": GB10_ONLY_BRANCH},
+            "Single PR with only GB10_BUILD diff vs main, working tree has UV (different substantive)",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": GB10_ONLY_DIFF},
              "fetch_exit": 0},
-            1,  # proceed (branch has no substantive change)
+            1,  # proceed (branch has no substantive change vs main)
         ),
         (
             "Single PR with different substantive changes (VLLM_REF vs UV_VERSION)",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": VLLM_AND_GB10_BRANCH},
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": VLLM_AND_GB10_DIFF},
              "fetch_exit": 0},
             1,  # proceed (different variables changed)
         ),
         (
             "Single PR with same UV but different GB10_BUILD (same substantive)",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": SIMPLE_DIFF},
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": SIMPLE_UV_DIFF},
              "fetch_exit": 0},
             0,  # skip (same UV change, GB10_BUILD differs but ignored)
         ),
         (
             "Multiple PRs, none matching",
             '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-41": VLLM_AND_GB10_BRANCH, "deps/bump-42": VLLM_AND_GB10_BRANCH},
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-41": VLLM_AND_GB10_DIFF, "deps/bump-42": VLLM_AND_GB10_DIFF},
              "fetch_exit": 0},
             1,  # proceed
         ),
         (
             "Multiple PRs, second one matches",
             '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-41": VLLM_AND_GB10_BRANCH, "deps/bump-42": None},  # second matches exactly
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-41": VLLM_AND_GB10_DIFF, "deps/bump-42": UV_AND_GB10_DIFF},
              "fetch_exit": 0},
             0,  # skip (second one matches)
         ),
         (
             "Multiple PRs, all match",
             '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-41": None, "deps/bump-42": None},  # both match exactly
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-41": UV_AND_GB10_DIFF, "deps/bump-42": UV_AND_GB10_DIFF},
              "fetch_exit": 0},
             0,  # skip (first match short-circuits)
         ),
         (
             "gh returns single object not array",
             '{"number": 42, "headRefName": "deps/bump-42"}',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": None},  # matching exactly
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": UV_AND_GB10_DIFF},
              "fetch_exit": 0},
             0,  # skip
         ),
         (
             "gh pr list errors (network issue)",
             "",
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {},
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {},
              "fetch_exit": 0},
             1,  # proceed (fails open)
         ),
         (
             "gh returns empty array (no matching PRs)",
             "[]",
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {},
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {},
              "fetch_exit": 0},
             1,  # proceed
         ),
         (
             "git fetch fails for the PR branch (rate limited)",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {},
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {},
              "fetch_exit": 1},  # fetch fails
             1,  # proceed (fetch failure shouldn't block)
         ),
         (
-            "Branch has no substantive changes (GB10_BUILD only) but working tree does",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": UV_AND_GB10_BRANCH,
-             "branch_diffs": {"deps/bump-42": GB10_ONLY_BRANCH},
+            "Branch has only GB10_BUILD change vs main, working tree has UV",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": GB10_ONLY_DIFF},
              "fetch_exit": 0},
             1,  # proceed (different substantive content)
         ),
         (
-            "Working tree has only GB10_BUILD, branch has substantive changes",
-            '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"working_diff": GB10_ONLY_BRANCH,
-             "branch_diffs": {"deps/bump-42": UV_AND_GB10_BRANCH},
+            "Working tree has only GB10_BUILD, branch has substantive vs main",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": GB10_ONLY_DIFF,
+             "branch_diffs_vs_main": {"deps/bump-42": UV_AND_GB10_DIFF},
              "fetch_exit": 0},
             0,  # skip (no substantive changes in working tree)
         ),
@@ -275,7 +254,7 @@ if __name__ == "__main__":
         print(f"Scenario: {name}")
         with tempfile.TemporaryDirectory() as tmpdir:
             working_diff = fake_git_behaviors["working_diff"]
-            branch_diffs = fake_git_behaviors.get("branch_diffs", {})
+            branch_diffs_vs_main = fake_git_behaviors.get("branch_diffs_vs_main", {})
             fetch_exit = fake_git_behaviors.get("fetch_exit", 0)
 
             # Create mock gh script
@@ -308,19 +287,19 @@ if __name__ == "__main__":
                 f.write(f"  exit {fetch_exit}\n")
                 f.write("fi\n")
 
-                # Handle "git diff --exit-code origin/<branch> -- versions.env"
-                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [[ "$3" =~ ^origin/ ]] && [ "$4" = "--" ] && [ "$5" = "versions.env" ] && [ $# -eq 5 ]; then\n')
-                if branch_diffs:
+                # Handle "git diff --exit-code origin/main origin/<branch> -- versions.env"
+                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [ "$3" = "origin/main" ] && [[ "$4" =~ ^origin/ ]] && [ "$5" = "--" ] && [ "$6" = "versions.env" ] && [ $# -eq 6 ]; then\n')
+                if branch_diffs_vs_main:
                     i=0
-                    for br, diff_content in branch_diffs.items():
+                    for br, diff_content in branch_diffs_vs_main.items():
                         prefix = "elif" if i > 0 else "if"
                         i+=1
                         if diff_content is not None:
-                            f.write(f'  {prefix} [ "$3" = "origin/{br}" ]; then\n')
+                            f.write(f'  {prefix} [ "$4" = "origin/{br}" ]; then\n')
                             f.write(f'    cat << \'ENDDIFF\'\n{diff_content}\nENDDIFF\n')
                             f.write("    exit 1\n")
                         else:
-                            f.write(f'  {prefix} [ "$3" = "origin/{br}" ]; then\n')
+                            f.write(f'  {prefix} [ "$4" = "origin/{br}" ]; then\n')
                             f.write("    exit 0\n")
                     f.write("  else\n")
                     f.write("    exit 1\n")

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -118,6 +118,46 @@ if __name__ == "__main__":
              "diff_branch_exit": 0},
             1,  # proceed (fails open)
         ),
+        (
+            "gh pr list returns empty array (no PRs)",
+            "[]",
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},
+            1,  # proceed
+        ),
+        (
+            "gh pr list returns non-JSON output (stale/weird token)",
+            "",
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},
+            1,  # proceed (json.loads will crash but script catches via stdout empty check)
+        ),
+        (
+            "Multiple PRs, all match",
+            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": [0, 0]},  # both match
+            0,  # skip (first match short-circuits)
+        ),
+        (
+            "Single PR, git fetch fails (rate-limited or branch deleted)",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,
+             "fetch_exit": 1,  # git fetch fails
+             "diff_branch_exit": 0},  # diff not reached
+            1,  # proceed (fetch failure should not block PR creation)
+        ),
+        (
+            "versions.env changes but lockfiles only changed (no component version change)",
+            "",
+            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes, e.g. GB10_BUILD)
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},
+            1,  # proceed (no PRs exist, should proceed)
+        ),
     ]
 
     script_path = os.path.join(

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/check-duplicate-pr.py logic.
+
+Tests the core check function in isolation (without calling gh/git).
+
+Scenario coverage:
+  - No changes in working tree (skip)
+  - No open PRs found (proceed)
+  - Single PR with matching versions.env (skip)
+  - Single PR with different versions.env (proceed)
+  - Multiple PRs, none matching (proceed)
+  - Multiple PRs, one matching (skip)
+"""
+
+import sys
+import textwrap
+
+sys.path.insert(0, "scripts")
+
+# We test the internal logic by patching run_git/run_gh, but since we can't
+# easily monkey-patch in a subprocess, we test the decision logic directly.
+# The script's exit code behavior is validated via subprocess tests below.
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Run check-duplicate-pr.py in a subprocess with fake gh/git
+    # This is done by creating a temporary script that shadows the real gh/git
+    import os
+    import subprocess
+    import tempfile
+
+    passed = 0
+    failed = 0
+
+    def check(condition, message):
+        global passed, failed
+        if condition:
+            passed += 1
+        else:
+            failed += 1
+            print(f"  FAIL: {message}", file=sys.stderr)
+
+    # Build test scenarios simulating different gh/git responses
+    # Each scenario is a tuple:
+    #   (name, fake_gh_stdout, fake_git_diff_exit_codes, expected_exit_code)
+    #
+    # fake_gh_stdout: what gh pr list returns (empty string = no PRs)
+    # fake_git_diff_exit_codes: list of exit codes for each git diff --exit-code call
+    # expected_exit_code: 0 = skip, 1 = proceed
+    #
+    # The test harness creates mock scripts for gh and git that return
+    # the specified outputs and exit codes.
+
+    scenarios = [
+        (
+            "No changes in working tree (git diff versions.env exits 0)",
+            # gh not called since git diff shows no changes
+            "",
+            {"diff_exit": 0},  # git diff versions.env exits 0 -> no changes
+            0,  # skip (no changes to PR)
+        ),
+        (
+            "Working tree has changes, no open PRs (gh returns empty)",
+            "",  # gh pr list returns nothing
+            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},  # branch diff not checked (no PRs)
+            1,  # proceed
+        ),
+        (
+            "Working tree has changes, single PR with matching diff",
+            # gh returns one PR: #42 on branch deps/bump-42
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},  # git diff origin/deps/bump-42 exits 0 (matching)
+            0,  # skip (matching PR found)
+        ),
+        (
+            "Working tree has changes, single PR with different diff",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
+             "fetch_exit": 0,
+             "diff_branch_exit": 1},  # git diff origin/deps/bump-42 exits 1 (different)
+            1,  # proceed (no match)
+        ),
+        (
+            "Multiple PRs, none matching",
+            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
+             "fetch_exit": 0,
+             "diff_branch_exit": [1, 1]},  # both PRs have different diffs
+            1,  # proceed
+        ),
+        (
+            "Multiple PRs, second one matches",
+            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": [1, 0]},  # first doesn't match, second does
+            0,  # skip
+        ),
+        (
+            "Single PR returns single object (not array) from gh",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},
+            0,  # skip
+        ),
+        (
+            "gh pr list errors (network issue)",
+            "",  # stderr handled via check=False
+            {"diff_exit": 1,
+             "fetch_exit": 0,
+             "diff_branch_exit": 0},
+            1,  # proceed (fails open)
+        ),
+    ]
+
+    script_path = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "check-duplicate-pr.py"
+    )
+    script_path = os.path.abspath(script_path)
+
+    for name, fake_gh_stdout, fake_git_behaviors, expected_exit in scenarios:
+        print(f"Scenario: {name}")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mock gh script
+            mock_gh = os.path.join(tmpdir, "gh")
+            with open(mock_gh, "w") as f:
+                f.write("#!/usr/bin/env bash\n")
+                if fake_gh_stdout:
+                    f.write(f'cat << \'ENDJSON\'\n{fake_gh_stdout}\nENDJSON\n')
+                else:
+                    f.write("exit 0\n")
+            os.chmod(mock_gh, 0o755)
+
+            # Create mock git script
+            mock_git = os.path.join(tmpdir, "git")
+            diff_exit = fake_git_behaviors.get("diff_exit", 0)
+            fetch_exit = fake_git_behaviors.get("fetch_exit", 0)
+            diff_branch_exit = fake_git_behaviors.get("diff_branch_exit", 0)
+
+            with open(mock_git, "w") as f:
+                f.write("#!/usr/bin/env bash\n")
+
+                # Handle "git diff --exit-code versions.env" (bare, no branch)
+                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [ "$3" = "versions.env" ]; then\n')
+                f.write(f"  exit {diff_exit}\n")
+                f.write("fi\n")
+
+                # Handle "git fetch origin <branch>"
+                f.write('if [ "$1" = "fetch" ]; then\n')
+                f.write(f"  exit {fetch_exit}\n")
+                f.write("fi\n")
+
+                # Handle "git diff --exit-code origin/<branch> -- versions.env"
+                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [[ "$3" =~ ^origin/ ]]; then\n')
+                if isinstance(diff_branch_exit, list):
+                    # Use a counter file to track which invocation
+                    f.write('  COUNTER_FILE="' + tmpdir + '/diff_counter"\n')
+                    f.write('  if [ ! -f "$COUNTER_FILE" ]; then echo 0 > "$COUNTER_FILE"; fi\n')
+                    f.write('  COUNTER=$(cat "$COUNTER_FILE")\n')
+                    f.write('  echo $((COUNTER + 1)) > "$COUNTER_FILE"\n')
+                    for i, code in enumerate(diff_branch_exit):
+                        f.write(f'  if [ "$COUNTER" = "{i}" ]; then exit {code}; fi\n')
+                    f.write(f"  exit {diff_branch_exit[-1]}\n")
+                else:
+                    f.write(f"  exit {diff_branch_exit}\n")
+                f.write("fi\n")
+
+                # Default: pass through to real git for other commands
+                f.write('exec /usr/bin/git "$@"\n')
+            os.chmod(mock_git, 0o755)
+
+            # Run the script with mocked PATH
+            env = os.environ.copy()
+            env["PATH"] = f"{tmpdir}:{env['PATH']}"
+            env["GH_TOKEN"] = "fake-token"
+
+            result = subprocess.run(
+                [sys.executable, script_path],
+                capture_output=True, text=True, env=env,
+            )
+
+            actual_exit = result.returncode
+            check(
+                actual_exit == expected_exit,
+                f"Expected exit {expected_exit}, got {actual_exit}. stdout: {result.stdout.strip()}",
+            )
+
+            # Show the script's output
+            for line in result.stdout.strip().splitlines():
+                print(f"  {line}")
+
+        print()
+
+    print(f"FAIL: {failed}")
+    if failed:
+        print(f"FAILED: {failed} of {passed + failed} checks failed")
+        sys.exit(1)
+    else:
+        print(f"All {passed} checks passed!")
+        sys.exit(0)

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -6,11 +6,21 @@ Tests the core check function in isolation (without calling gh/git).
 
 Scenario coverage:
   - No changes in working tree (skip)
-  - No open PRs found (proceed)
-  - Single PR with matching versions.env (skip)
-  - Single PR with different versions.env (proceed)
+  - Only GB10_BUILD changes (skip - not substantive)
+  - Substantive changes, no open PRs (proceed)
+  - Single PR with matching substantive changes (skip)
+  - Single PR with different substantive changes (proceed)
+  - Single PR with only GB10_BUILD diff, working tree has UV (proceed - different substantive)
+  - Single PR with same UV but different GB10_BUILD (skip - same substantive, GB10 ignored)
   - Multiple PRs, none matching (proceed)
-  - Multiple PRs, one matching (skip)
+  - Multiple PRs, second one matches (skip)
+  - Multiple PRs, all match (skip - first match short-circuits)
+  - gh returns single object not array (skip)
+  - gh pr list errors/network issue (proceed - fails open)
+  - gh returns empty array (proceed)
+  - git fetch fails (proceed - fetch failure shouldn't block)
+  - Branch has no substantive changes but working tree does (proceed)
+  - Working tree has only GB10_BUILD, branch has substantive (skip - no substantive changes)
 """
 
 import sys
@@ -18,15 +28,89 @@ import textwrap
 
 sys.path.insert(0, "scripts")
 
-# We test the internal logic by patching run_git/run_gh, but since we can't
-# easily monkey-patch in a subprocess, we test the decision logic directly.
-# The script's exit code behavior is validated via subprocess tests below.
-
 
 # ---------------------------------------------------------------------------
+# Helpers to generate realistic unified diff output for mock git
+# ---------------------------------------------------------------------------
+
+SIMPLE_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -20,6 +20,6 @@ GB10_BUILD=2
+ # Python / uv bootstrap
+ # ---------------------------------------------------------------------------
+-UV_VERSION=0.11.29
++UV_VERSION=0.11.30
+"""
+
+# Diff with only GB10_BUILD change (should be treated as no substantive change)
+GB10_ONLY_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
+ # Image stack revision.
+ # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
+ # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
+-GB10_BUILD=2
++GB10_BUILD=3
+"""
+
+# Diff with BOTH UV_VERSION and GB10_BUILD change (UV is substantive)
+UV_AND_GB10_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
+ # Image stack revision.
+ # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
+ # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
+-GB10_BUILD=2
++GB10_BUILD=3
+@@ -20,6 +20,6 @@ GB10_BUILD=3
+ # Python / uv bootstrap
+ # ---------------------------------------------------------------------------
+-UV_VERSION=0.11.29
++UV_VERSION=0.11.30
+"""
+
+# Diff with a completely different variable (VLLM_REF instead of UV_VERSION)
+VLLM_REF_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -28,6 +28,6 @@ GB10_BUILD=2
+ # vLLM
+ # ---------------------------------------------------------------------------
+-VLLM_REF=v0.24.0
++VLLM_REF=v0.25.1
+"""
+
+# Diff with BOTH VLLM_REF and GB10_BUILD change
+VLLM_AND_GB10_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -28,6 +28,6 @@ GB10_BUILD=2
+ # vLLM
+ # ---------------------------------------------------------------------------
+-VLLM_REF=v0.24.0
++VLLM_REF=v0.25.1
+@@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
+ # Image stack revision.
+ # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
+ # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
+-GB10_BUILD=2
++GB10_BUILD=3
+"""
+
 if __name__ == "__main__":
-    # Run check-duplicate-pr.py in a subprocess with fake gh/git
-    # This is done by creating a temporary script that shadows the real gh/git
     import os
     import subprocess
     import tempfile
@@ -42,121 +126,143 @@ if __name__ == "__main__":
             failed += 1
             print(f"  FAIL: {message}", file=sys.stderr)
 
-    # Build test scenarios simulating different gh/git responses
+    # Build test scenarios
     # Each scenario is a tuple:
-    #   (name, fake_gh_stdout, fake_git_diff_exit_codes, expected_exit_code)
+    #   (name, fake_gh_stdout, fake_git_behaviors, expected_exit_code)
     #
-    # fake_gh_stdout: what gh pr list returns (empty string = no PRs)
-    # fake_git_diff_exit_codes: list of exit codes for each git diff --exit-code call
-    # expected_exit_code: 0 = skip, 1 = proceed
-    #
-    # The test harness creates mock scripts for gh and git that return
-    # the specified outputs and exit codes.
+    # fake_gh_stdout: what gh pr list returns (empty string = no PRs, or error)
+    # fake_git_behaviors dict:
+    #   working_diff: the diff text to return for working tree diff, or None for exit 0
+    #   branch_diffs: dict mapping branch name -> diff text, or None for exit 0
+    #   fetch_exit: exit code for git fetch (0 = success, 1 = failure)
+
+    GB10_ONLY_BRANCH = GB10_ONLY_DIFF
+    UV_AND_GB10_BRANCH = UV_AND_GB10_DIFF
+    VLLM_AND_GB10_BRANCH = VLLM_AND_GB10_DIFF
+    EMPTY = None  # No diff (exit 0)
 
     scenarios = [
         (
             "No changes in working tree (git diff versions.env exits 0)",
-            # gh not called since git diff shows no changes
             "",
-            {"diff_exit": 0},  # git diff versions.env exits 0 -> no changes
-            0,  # skip (no changes to PR)
+            {"working_diff": EMPTY, "branch_diffs": {}, "fetch_exit": 0},
+            0,  # skip (no changes)
         ),
         (
-            "Working tree has changes, no open PRs (gh returns empty)",
-            "",  # gh pr list returns nothing
-            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},  # branch diff not checked (no PRs)
+            "Only GB10_BUILD changes in working tree (not substantive)",
+            "",
+            {"working_diff": GB10_ONLY_BRANCH, "branch_diffs": {}, "fetch_exit": 0},
+            0,  # skip (no substantive changes)
+        ),
+        (
+            "Substantive changes (UV_VERSION + GB10_BUILD), no open PRs",
+            "",
+            {"working_diff": UV_AND_GB10_BRANCH, "branch_diffs": {}, "fetch_exit": 0},
             1,  # proceed
         ),
         (
-            "Working tree has changes, single PR with matching diff",
-            # gh returns one PR: #42 on branch deps/bump-42
+            "Single PR with matching substantive changes (UV_VERSION + GB10_BUILD)",
             '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},  # git diff origin/deps/bump-42 exits 0 (matching)
-            0,  # skip (matching PR found)
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": None},  # exit 0 = same as working tree
+             "fetch_exit": 0},
+            0,  # skip
         ),
         (
-            "Working tree has changes, single PR with different diff",
+            "Single PR with only GB10_BUILD diff, working tree has UV (different substantive)",
             '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
-             "fetch_exit": 0,
-             "diff_branch_exit": 1},  # git diff origin/deps/bump-42 exits 1 (different)
-            1,  # proceed (no match)
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": GB10_ONLY_BRANCH},
+             "fetch_exit": 0},
+            1,  # proceed (branch has no substantive change)
+        ),
+        (
+            "Single PR with different substantive changes (VLLM_REF vs UV_VERSION)",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": VLLM_AND_GB10_BRANCH},
+             "fetch_exit": 0},
+            1,  # proceed (different variables changed)
+        ),
+        (
+            "Single PR with same UV but different GB10_BUILD (same substantive)",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": SIMPLE_DIFF},
+             "fetch_exit": 0},
+            0,  # skip (same UV change, GB10_BUILD differs but ignored)
         ),
         (
             "Multiple PRs, none matching",
-            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes)
-             "fetch_exit": 0,
-             "diff_branch_exit": [1, 1]},  # both PRs have different diffs
+            '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-41": VLLM_AND_GB10_BRANCH, "deps/bump-42": VLLM_AND_GB10_BRANCH},
+             "fetch_exit": 0},
             1,  # proceed
         ),
         (
             "Multiple PRs, second one matches",
-            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": [1, 0]},  # first doesn't match, second does
-            0,  # skip
+            '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-41": VLLM_AND_GB10_BRANCH, "deps/bump-42": None},  # second matches exactly
+             "fetch_exit": 0},
+            0,  # skip (second one matches)
         ),
         (
-            "Single PR returns single object (not array) from gh",
+            "Multiple PRs, all match",
+            '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-41": None, "deps/bump-42": None},  # both match exactly
+             "fetch_exit": 0},
+            0,  # skip (first match short-circuits)
+        ),
+        (
+            "gh returns single object not array",
             '{"number": 42, "headRefName": "deps/bump-42"}',
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": None},  # matching exactly
+             "fetch_exit": 0},
             0,  # skip
         ),
         (
             "gh pr list errors (network issue)",
-            "",  # stderr handled via check=False
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},
+            "",
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {},
+             "fetch_exit": 0},
             1,  # proceed (fails open)
         ),
         (
-            "gh pr list returns empty array (no PRs)",
+            "gh returns empty array (no matching PRs)",
             "[]",
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {},
+             "fetch_exit": 0},
             1,  # proceed
         ),
         (
-            "gh pr list returns non-JSON output (stale/weird token)",
-            "",
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},
-            1,  # proceed (json.loads will crash but script catches via stdout empty check)
-        ),
-        (
-            "Multiple PRs, all match",
-            '[{"number": 41, "headRefName": "deps/bump-41"}, {"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,
-             "fetch_exit": 0,
-             "diff_branch_exit": [0, 0]},  # both match
-            0,  # skip (first match short-circuits)
-        ),
-        (
-            "Single PR, git fetch fails (rate-limited or branch deleted)",
+            "git fetch fails for the PR branch (rate limited)",
             '[{"number": 42, "headRefName": "deps/bump-42"}]',
-            {"diff_exit": 1,
-             "fetch_exit": 1,  # git fetch fails
-             "diff_branch_exit": 0},  # diff not reached
-            1,  # proceed (fetch failure should not block PR creation)
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {},
+             "fetch_exit": 1},  # fetch fails
+            1,  # proceed (fetch failure shouldn't block)
         ),
         (
-            "versions.env changes but lockfiles only changed (no component version change)",
-            "",
-            {"diff_exit": 1,  # git diff versions.env exits 1 (has changes, e.g. GB10_BUILD)
-             "fetch_exit": 0,
-             "diff_branch_exit": 0},
-            1,  # proceed (no PRs exist, should proceed)
+            "Branch has no substantive changes (GB10_BUILD only) but working tree does",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"working_diff": UV_AND_GB10_BRANCH,
+             "branch_diffs": {"deps/bump-42": GB10_ONLY_BRANCH},
+             "fetch_exit": 0},
+            1,  # proceed (different substantive content)
+        ),
+        (
+            "Working tree has only GB10_BUILD, branch has substantive changes",
+            '[{"number": 42, "headRefName": "deps/bump-42"}]',
+            {"working_diff": GB10_ONLY_BRANCH,
+             "branch_diffs": {"deps/bump-42": UV_AND_GB10_BRANCH},
+             "fetch_exit": 0},
+            0,  # skip (no substantive changes in working tree)
         ),
     ]
 
@@ -168,6 +274,10 @@ if __name__ == "__main__":
     for name, fake_gh_stdout, fake_git_behaviors, expected_exit in scenarios:
         print(f"Scenario: {name}")
         with tempfile.TemporaryDirectory() as tmpdir:
+            working_diff = fake_git_behaviors["working_diff"]
+            branch_diffs = fake_git_behaviors.get("branch_diffs", {})
+            fetch_exit = fake_git_behaviors.get("fetch_exit", 0)
+
             # Create mock gh script
             mock_gh = os.path.join(tmpdir, "gh")
             with open(mock_gh, "w") as f:
@@ -180,36 +290,43 @@ if __name__ == "__main__":
 
             # Create mock git script
             mock_git = os.path.join(tmpdir, "git")
-            diff_exit = fake_git_behaviors.get("diff_exit", 0)
-            fetch_exit = fake_git_behaviors.get("fetch_exit", 0)
-            diff_branch_exit = fake_git_behaviors.get("diff_branch_exit", 0)
-
             with open(mock_git, "w") as f:
                 f.write("#!/usr/bin/env bash\n")
+                f.write('set -o pipefail\n')
 
-                # Handle "git diff --exit-code versions.env" (bare, no branch)
-                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [ "$3" = "versions.env" ]; then\n')
-                f.write(f"  exit {diff_exit}\n")
+                # Handle "git diff --exit-code HEAD -- versions.env" (working tree vs HEAD)
+                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [ "$3" = "HEAD" ] && [ "$4" = "--" ] && [ "$5" = "versions.env" ] && [ $# -eq 5 ]; then\n')
+                if working_diff is not None:
+                    f.write(f'  cat << \'ENDDIFF\'\n{working_diff}\nENDDIFF\n')
+                    f.write("  exit 1\n")
+                else:
+                    f.write("  exit 0\n")
                 f.write("fi\n")
 
                 # Handle "git fetch origin <branch>"
-                f.write('if [ "$1" = "fetch" ]; then\n')
+                f.write('if [ "$1" = "fetch" ] && [ "$2" = "origin" ] && [ $# -eq 3 ]; then\n')
                 f.write(f"  exit {fetch_exit}\n")
                 f.write("fi\n")
 
                 # Handle "git diff --exit-code origin/<branch> -- versions.env"
-                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [[ "$3" =~ ^origin/ ]]; then\n')
-                if isinstance(diff_branch_exit, list):
-                    # Use a counter file to track which invocation
-                    f.write('  COUNTER_FILE="' + tmpdir + '/diff_counter"\n')
-                    f.write('  if [ ! -f "$COUNTER_FILE" ]; then echo 0 > "$COUNTER_FILE"; fi\n')
-                    f.write('  COUNTER=$(cat "$COUNTER_FILE")\n')
-                    f.write('  echo $((COUNTER + 1)) > "$COUNTER_FILE"\n')
-                    for i, code in enumerate(diff_branch_exit):
-                        f.write(f'  if [ "$COUNTER" = "{i}" ]; then exit {code}; fi\n')
-                    f.write(f"  exit {diff_branch_exit[-1]}\n")
+                f.write('if [ "$1" = "diff" ] && [ "$2" = "--exit-code" ] && [[ "$3" =~ ^origin/ ]] && [ "$4" = "--" ] && [ "$5" = "versions.env" ] && [ $# -eq 5 ]; then\n')
+                if branch_diffs:
+                    i=0
+                    for br, diff_content in branch_diffs.items():
+                        prefix = "elif" if i > 0 else "if"
+                        i+=1
+                        if diff_content is not None:
+                            f.write(f'  {prefix} [ "$3" = "origin/{br}" ]; then\n')
+                            f.write(f'    cat << \'ENDDIFF\'\n{diff_content}\nENDDIFF\n')
+                            f.write("    exit 1\n")
+                        else:
+                            f.write(f'  {prefix} [ "$3" = "origin/{br}" ]; then\n')
+                            f.write("    exit 0\n")
+                    f.write("  else\n")
+                    f.write("    exit 1\n")
+                    f.write("  fi\n")
                 else:
-                    f.write(f"  exit {diff_branch_exit}\n")
+                    f.write("  exit 1\n")
                 f.write("fi\n")
 
                 # Default: pass through to real git for other commands


### PR DESCRIPTION
Extract duplicate PR detection into a testable script with comprehensive edge case coverage. Updates the upstream monitor workflow to call it cleanly instead of inline Python.

Changes:

- Move duplicate PR detection to `scripts/check-duplicate-pr.py`
- `GB10_BUILD` is now ignored when comparing versions.env changes - only substantive component bumps matter
- Compare both working tree and each PR branch against `origin/main` for fair comparison
- Handle NDJSON output from `gh --jq '.[]'` correctly (one JSON per line for multiple PRs)
- 16 test scenarios in `tests/test-check-duplicate-pr.py`
- Test runs in CI alongside release notes and PR body tests