### PR TITLE
fix(release-automation): harden update and release scripts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - dgx-spark

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -104,7 +104,9 @@ jobs:
         # step outputs so downstream jobs can reuse them without
         # re-sourcing versions.env.
         run: |
-          CUDA_SHORT="cu$(echo "$CUDA_BASE_IMAGE" | sed 's/.*cuda:\([0-9]*\.[0-9]*\)\.[0-9]*.*/\1/')"
+          CUDA_VERSION="${CUDA_BASE_IMAGE#*cuda:}"
+          CUDA_VERSION="${CUDA_VERSION%%-*}"
+          CUDA_SHORT="cu${CUDA_VERSION%.*}"
           TORCH_SHORT="torch$(echo "$TORCH_VERSION" | cut -d. -f1-2)"
           SHA_TAG="sha-$(git rev-parse --short HEAD)"
           CANONICAL="${VLLM_REF}-gb10.${GB10_BUILD}"
@@ -272,6 +274,9 @@ jobs:
       - name: Checkout
         # Needed for `git tag` / `git push` of the release tag.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # Release notes compare the current tag with the previous release.
+          fetch-depth: 0
 
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # Release notes compare the current tag with the previous release.
+          fetch-depth: 0
 
       - name: Generate release notes
         env:

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -32,13 +32,16 @@ jobs:
       - name: Check for dependency updates
         id: check
         run: |
-          scripts/check-updates.sh > /tmp/check-updates.log 2>&1 || true
+          if ! scripts/check-updates.sh > /tmp/check-updates.log 2>&1; then
+            cat /tmp/check-updates.log
+            exit 1
+          fi
           cat /tmp/check-updates.log
           
           if grep -q "have updates available" /tmp/check-updates.log; then
-            echo "has-update=true" >> $GITHUB_OUTPUT
+            echo "has-update=true" >> "$GITHUB_OUTPUT"
           else
-            echo "has-update=false" >> $GITHUB_OUTPUT
+            echo "has-update=false" >> "$GITHUB_OUTPUT"
           fi
 
   create-pr:
@@ -58,9 +61,9 @@ jobs:
         id: changes
         run: |
           if git diff --exit-code versions.env > /dev/null 2>&1; then
-            echo "has-changes=false" >> $GITHUB_OUTPUT
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo "has-changes=true" >> $GITHUB_OUTPUT
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check for existing PR with same changes

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -15,7 +15,12 @@ name: Test release notes
 on:
   pull_request:
     paths:
+      - scripts/check-updates.sh
+      - scripts/generate-pr-body.sh
       - scripts/generate-release-notes.sh
+      - scripts/versions_diff.py
+      - tests/test-check-updates.py
+      - tests/test-script-integrations.py
       - tests/test-release-notes-scenarios.py
       - tests/test-pr-body-generation.py
       - tests/test-check-duplicate-pr.py
@@ -41,8 +46,14 @@ jobs:
       - name: Run release-notes test harness
         run: python3 tests/test-release-notes-scenarios.py
 
+      - name: Run update-check test harness
+        run: python3 tests/test-check-updates.py
+
       - name: Run PR body generation test harness
         run: python3 tests/test-pr-body-generation.py
+
+      - name: Run real-script integration tests
+        run: python3 tests/test-script-integrations.py
 
       - name: Run duplicate PR check test harness
         run: python3 tests/test-check-duplicate-pr.py
@@ -53,7 +64,7 @@ jobs:
 
           # Count code fences - must be even (open + close pairs)
           # Lines that start with optional whitespace followed by exactly 3 backticks
-          FENCES=$(grep -cE '^\s*```' "$OUTPUT")
+          FENCES=$(grep -cE '^[[:space:]]*```' "$OUTPUT")
           if [ $((FENCES % 2)) -ne 0 ]; then
             echo "ERROR: Odd number of code fences ($FENCES) in output - markdown is broken."
             exit 1
@@ -71,7 +82,8 @@ jobs:
 
           # Verify no raw triple-backtick fences inside rendered output blocks
           # (they should be escaped with zero-width space)
-          INNER_FENCES=$(grep -cP '`\x{200b}``' "$OUTPUT")
+          # shellcheck disable=SC2016
+          INNER_FENCES=$(python3 -c 'import sys; print(open(sys.argv[1]).read().count("`\u200b``"))' "$OUTPUT")
           echo "OK: $INNER_FENCES inner code fences properly escaped"
 
       - name: Upload test output artifact

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -73,20 +73,28 @@ for arg in "$@"; do
   esac
 done
 
+if [[ "${DO_UPDATE}" -eq 1 && "${DO_BUMP_APT}" -eq 1 ]]; then
+  printf '%s\n' 'Choose either --update or --bump-apt-snapshot, not both.' >&2
+  exit 1
+fi
+
 log()  { printf '[check-updates] %s\n' "$*" >&2; }
 need() { command -v "$1" &>/dev/null || { log "Required tool '$1' not found."; exit 1; }; }
 
 need curl
 need python3
 
-# shellcheck source=../versions.env
-set -a; source "${VERSIONS}"; set +a
+set -a
+# shellcheck disable=SC1090,SC1091
+source "${VERSIONS}"
+set +a
 
 OK="OK     "
 OUT="UPDATE "
 
 # Tracks whether any updates were found
 UPDATES=0
+ENV_UPDATES=0
 
 # ---------------------------------------------------------------------------
 # sed -i is not portable between macOS and Linux. Use a temp-file swap.
@@ -95,9 +103,15 @@ update_env() {
   local key="$1"
   local val="$2"
   local tmp
+  if ! grep -q "^${key}=" "${VERSIONS}"; then
+    log "Cannot update missing key ${key} in versions.env."
+    return 1
+  fi
   tmp="$(mktemp)"
   sed "s|^${key}=.*|${key}=${val}|" "${VERSIONS}" > "${tmp}"
+  chmod 0644 "${tmp}"
   mv "${tmp}" "${VERSIONS}"
+  ENV_UPDATES=$((ENV_UPDATES + 1))
   log "  updated ${key}=${val}"
 }
 
@@ -116,6 +130,7 @@ update_apt_snapshot() {
     -e "s|/[0-9]\{8\}T[0-9]\{6\}Z/|/${new_stamp}/|g" \
     -e "s|# Snapshot date: .*|# Snapshot date: ${new_display}T00:00:00Z|" \
     "${sources}" > "${tmp}"
+  chmod 0644 "${tmp}"
   mv "${tmp}" "${sources}"
   log "  updated apt-sources.list snapshot -> ${new_display}T00:00:00Z"
 }
@@ -158,6 +173,10 @@ load_vllm_reqs() {
       curl -fsSL "${base}/requirements/build/cuda.txt" 2>/dev/null || true
     }
   )"
+  if [[ -z "${VLLM_REQS_RAW//[[:space:]]/}" ]]; then
+    log "Could not fetch vLLM requirements for ${tag}."
+    return 1
+  fi
 }
 
 vllm_pin() {
@@ -203,43 +222,56 @@ VLLM_LATEST=$(gh_latest_tag "vllm-project/vllm")
 # newer than the latest stable (e.g. v0.23.0) is reported as INFO, not UPDATE.
 # Only flag UPDATE when the stable release is genuinely ahead of our pin.
 VLLM_CMP=$(python3 -c "
-from packaging.version import Version
-cur = Version('${VLLM_REF}'.lstrip('v'))
-lat = Version('${VLLM_LATEST}'.lstrip('v'))
+import re
+
+def parse(value):
+    match = re.fullmatch(r'v?(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?', value)
+    if not match:
+        raise ValueError(value)
+    major, minor, patch, stage, number = match.groups()
+    stage_rank = {'a': 0, 'b': 1, 'rc': 2, None: 3}[stage]
+    return (int(major), int(minor), int(patch), stage_rank, int(number or 0))
+
+cur = parse('${VLLM_REF}')
+lat = parse('${VLLM_LATEST}')
 print('ahead' if cur >= lat else 'behind')
 " 2>/dev/null || echo 'unknown')
 if [ "${VLLM_CMP}" = "behind" ]; then
+  VLLM_TARGET="${VLLM_LATEST}"
   report "vLLM (VLLM_REF)" "VLLM_REF" "${VLLM_REF}" "${VLLM_LATEST}"
 elif [ "${VLLM_CMP}" = "ahead" ] && [ "${VLLM_REF}" != "${VLLM_LATEST}" ]; then
+  VLLM_TARGET="${VLLM_REF}"
   printf 'INFO    %-30s current=%-20s stable=%s (pinned to newer pre-release)\n' \
     "vLLM (VLLM_REF)" "${VLLM_REF}" "${VLLM_LATEST}"
-else
+elif [ "${VLLM_CMP}" = "ahead" ]; then
+  VLLM_TARGET="${VLLM_REF}"
   printf '%s %-30s current=%-20s\n' "${OK}" "vLLM (VLLM_REF)" "${VLLM_REF}"
+else
+  log "Could not compare vLLM versions '${VLLM_REF}' and '${VLLM_LATEST}'."
+  exit 1
 fi
 
 # Load vLLM's pinned dep versions at the *target* tag so dependent components
 # below can be aligned to it (rather than blindly tracking PyPI latest).
-log "Fetching vLLM ${VLLM_LATEST} requirements for cross-checks..."
-load_vllm_reqs "${VLLM_LATEST}"
+log "Fetching vLLM ${VLLM_TARGET} requirements for cross-checks..."
+load_vllm_reqs "${VLLM_TARGET}"
 
 NCCL_LATEST=$(gh_latest_tag "NVIDIA/nccl")
 report "NCCL (NCCL_REF)" "NCCL_REF" "${NCCL_REF}" "${NCCL_LATEST}"
 
-# FlashInfer is constrained by vLLM's flashinfer-python pin at VLLM_REF, which
+# FlashInfer is constrained by vLLM's flashinfer-python pin at VLLM_TARGET, which
 # is the authoritative source of truth for this stack.  If our FLASHINFER_REF
 # already matches that constraint we are aligned -- do NOT flag a GitHub
 # "latest" as an update (upstream FlashInfer releases that are newer than what
-# the pinned vLLM expects would cause pip conflicts or ABI mismatches).
+# the target vLLM expects would cause pip conflicts or ABI mismatches).
 # Fall back to GH latest only when vLLM does not pin flashinfer-python at
-# VLLM_REF.
-log "Fetching vLLM ${VLLM_REF} requirements for FlashInfer constraint..."
-load_vllm_reqs "${VLLM_REF}"
+# VLLM_TARGET.
 FLASHINFER_PIN=$(vllm_pin "flashinfer-python")
 if [[ -n "${FLASHINFER_PIN}" ]]; then
   FLASHINFER_LATEST="v${FLASHINFER_PIN}"
   if [[ "${FLASHINFER_REF#v}" == "${FLASHINFER_PIN}" ]]; then
     printf '%s %-30s current=%-20s (aligned to VLLM %s pin)\n' \
-      "${OK}" "FlashInfer (FLASHINFER_REF)" "${FLASHINFER_REF}" "${VLLM_REF}"
+      "${OK}" "FlashInfer (FLASHINFER_REF)" "${FLASHINFER_REF}" "${VLLM_TARGET}"
   else
     printf '%s %-30s current=%-20s vLLM=%s (mismatch!)\n' \
       "${OUT}" "FlashInfer (FLASHINFER_REF)" "${FLASHINFER_REF}" "v${FLASHINFER_PIN}"
@@ -380,7 +412,7 @@ print((datetime.now(timezone.utc) - snap).days)
     fi
   elif [[ "${APT_SNAPSHOT_AGE}" -ge 30 ]]; then
     printf 'INFO    %-30s age=%d days (snapshot=%s) - consider refreshing soon\n' \
-      "" "apt snapshot" "${APT_SNAPSHOT_AGE}" "${APT_SNAPSHOT_DISPLAY}"
+      "apt snapshot" "${APT_SNAPSHOT_AGE}" "${APT_SNAPSHOT_DISPLAY}"
     if [[ "${DO_BUMP_APT}" -eq 1 ]]; then
       update_apt_snapshot "${TODAY_STAMP}"
     fi
@@ -399,7 +431,7 @@ if [ "${UPDATES}" -eq 0 ]; then
   echo "All components are current."
 else
   if [ "${DO_UPDATE}" -eq 1 ]; then
-    printf '%d component(s) updated in versions.env.\n' "${UPDATES}"
+    printf '%d component(s) updated in versions.env.\n' "${ENV_UPDATES}"
     echo ""
     echo "Next steps:"
     echo "  1. git diff versions.env          # review changes"

--- a/scripts/generate-pr-body.sh
+++ b/scripts/generate-pr-body.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
 
 # Determine what to diff against (origin/main or HEAD~1 as fallback)
 BASEREF="origin/main"
@@ -31,55 +32,65 @@ if git diff --exit-code "${BASEREF}" -- versions.env locks/ > /dev/null 2>&1; th
   exit 1
 fi
 
-export REPO_ROOT
+export BASEREF REPO_ROOT
 python3 - <<'PYEOF'
-import os, subprocess, sys, hashlib, re, textwrap
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 repo_root = os.environ["REPO_ROOT"]
 sys.path.insert(0, os.path.join(repo_root, "scripts"))
-from versions_diff import COMPONENT_LABELS, diff_from_git_diff, format_changes_with_lockfiles
+from versions_diff import (
+    COMPONENT_LABELS,
+    LOCKFILES,
+    diff_env_dicts,
+    extract_apt_snapshot_date,
+    file_sha256,
+    format_changes_with_lockfiles,
+    parse_versions_env,
+)
 
-baseref = os.environ.get("BASEREF", "origin/main")
+baseref = os.environ["BASEREF"]
 
-# 1. Parse versions.env diff
-diff = subprocess.run(
-    ["git", "diff", baseref, "--", "versions.env"],
+# 1. Compare the base versions.env with the current working-tree file.
+old_versions = subprocess.run(
+    ["git", "show", f"{baseref}:versions.env"],
     capture_output=True, text=True, check=True,
 ).stdout
-changes = diff_from_git_diff(diff)
+new_versions = Path(repo_root, "versions.env").read_text()
+changes = diff_env_dicts(
+    parse_versions_env(old_versions),
+    parse_versions_env(new_versions),
+)
 
 # 2. Check lockfile changes
-lockfiles = [
-    ("locks/apt-packages.txt", "apt packages"),
-    ("locks/apt-sources.list", "apt snapshot"),
-    ("locks/python-bootstrap.txt", "python bootstrap lock"),
-    ("locks/python-build.txt", "python build lock"),
-    ("locks/python-runtime.txt", "python runtime lock"),
-]
-
-for lock_path, lock_label in lockfiles:
+for lock_path, _lock_label in LOCKFILES:
     old_result = subprocess.run(
         ["git", "show", f"{baseref}:{lock_path}"],
         capture_output=True, text=True,
     )
-    new_result = subprocess.run(
-        ["git", "show", f"HEAD:{lock_path}"],
-        capture_output=True, text=True,
-    )
-    if old_result.returncode == 0 and new_result.returncode == 0 and old_result.stdout and new_result.stdout:
-        old_hash = hashlib.sha256(old_result.stdout.encode()).hexdigest()[:12]
-        new_hash = hashlib.sha256(new_result.stdout.encode()).hexdigest()[:12]
+    new_path = Path(repo_root, lock_path)
+    old_content = old_result.stdout if old_result.returncode == 0 else None
+    new_content = new_path.read_text() if new_path.is_file() else None
+
+    if old_content is not None and new_content is not None:
+        old_hash = file_sha256(old_content)
+        new_hash = file_sha256(new_content)
         if old_hash != new_hash:
-            # For apt-sources.list, show the snapshot date when it differs
             if lock_path == "locks/apt-sources.list":
-                m_old = re.search(r"snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)", old_result.stdout)
-                m_new = re.search(r"snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)", new_result.stdout)
-                if m_old and m_new and m_old.group(1) != m_new.group(1):
-                    changes[f"LOCK:{lock_path}"] = (m_old.group(1), m_new.group(1))
+                old_date = extract_apt_snapshot_date(old_content)
+                new_date = extract_apt_snapshot_date(new_content)
+                if old_date and new_date and old_date != new_date:
+                    changes[f"LOCK:{lock_path}"] = (old_date, new_date)
                 else:
                     changes[f"LOCK:{lock_path}"] = (f"sha256:{old_hash}", f"sha256:{new_hash}")
             else:
                 changes[f"LOCK:{lock_path}"] = (f"sha256:{old_hash}", f"sha256:{new_hash}")
+    elif old_content != new_content:
+        old_value = f"sha256:{file_sha256(old_content)}" if old_content is not None else "(missing)"
+        new_value = f"sha256:{file_sha256(new_content)}" if new_content is not None else "(missing)"
+        changes[f"LOCK:{lock_path}"] = (old_value, new_value)
 
 # Separate component changes from lockfile changes
 lock_keys = {k for k in changes if k.startswith("LOCK:")}

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -16,16 +16,21 @@ set -euo pipefail
 : "${TAG:?TAG env var required}"
 : "${GITHUB_SHA:?GITHUB_SHA env var required}"
 
-# shellcheck disable=SC1091
-set -a; . ./versions.env; set +a
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export REPO_ROOT
+cd "${REPO_ROOT}"
 
-SHORT_SHA="${GITHUB_SHA::7}"
+set -a
+# shellcheck disable=SC1090,SC1091
+. "${REPO_ROOT}/versions.env"
+set +a
 
 python3 - <<'PYEOF'
 import os, subprocess, textwrap, sys
 
-# Add scripts/ to sys.path so the shared module is importable
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__))))
+# Python is reading this program from stdin, so __file__ cannot locate the
+# script directory. Use the path resolved by the shell wrapper instead.
+sys.path.insert(0, os.path.join(os.environ["REPO_ROOT"], "scripts"))
 
 from versions_diff import (
     COMPONENT_LABELS,
@@ -120,7 +125,7 @@ def git_show_file(prev_tag, path):
 def read_current_file(path):
     """Read a file from the working tree."""
     try:
-        with open(path, "r") as f:
+        with open(os.path.join(os.environ["REPO_ROOT"], path), "r") as f:
             return f.read()
     except Exception:
         return None

--- a/scripts/versions_diff.py
+++ b/scripts/versions_diff.py
@@ -71,8 +71,8 @@ def diff_env_dicts(old_env, new_env):
     changes = {}
     all_keys = set(old_env.keys()) | set(new_env.keys())
     for key in sorted(all_keys):
-        old_val = old_env.get(key, "")
-        new_val = new_env.get(key, "")
+        old_val = old_env.get(key, "(added)")
+        new_val = new_env.get(key, "(removed)")
         if old_val != new_val:
             changes[key] = (old_val, new_val)
     return changes
@@ -85,19 +85,23 @@ def diff_from_git_diff(diff_text):
         -VLLM_REF=v0.24.0
         +VLLM_REF=v0.25.1
     """
+    old_env = {}
+    new_env = {}
+    for line in diff_text.splitlines():
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        match = re.match(r"^([-+])([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line)
+        if not match:
+            continue
+        destination = old_env if match.group(1) == "-" else new_env
+        destination[match.group(2)] = match.group(3)
+
     changes = {}
-    for m in re.finditer(r"^-([A-Za-z_][A-Za-z0-9_]*)=(.*)", diff_text, re.MULTILINE):
-        key = m.group(1)
-        old_val = m.group(2)
-        plus_m = re.search(
-            r"^\+" + re.escape(key) + r"=(.*)", diff_text, re.MULTILINE
-        )
-        if plus_m:
-            new_val = plus_m.group(1)
-            if old_val != new_val:
-                changes[key] = (old_val, new_val)
-                continue
-        changes[key] = (old_val, "(removed)")
+    for key in sorted(old_env.keys() | new_env.keys()):
+        old_val = old_env.get(key, "(added)")
+        new_val = new_env.get(key, "(removed)")
+        if old_val != new_val:
+            changes[key] = (old_val, new_val)
     return changes
 
 

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests for check-updates.sh using deterministic mocked upstream APIs."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SOURCE_ROOT = Path(__file__).resolve().parent.parent
+
+FAKE_CURL = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+
+url = sys.argv[-1]
+if os.environ.get("FAKE_FAIL_ALL") == "1":
+    sys.exit(22)
+if "raw.githubusercontent.com" in url:
+    if os.environ.get("FAKE_FAIL_RAW") == "1":
+        sys.exit(22)
+    if "/v0.26.0/" in url:
+        print("""torch==9.9.0
+torchvision==9.8.0
+torchaudio==9.7.0
+apache-tvm-ffi==9.6.0
+tilelang==9.5.0
+numba==9.4.0
+flashinfer-python==9.3.0""")
+    else:
+        print("""torch==2.11.0
+torchvision==0.26.0
+torchaudio==2.11.0
+apache-tvm-ffi==0.1.9
+tilelang==0.1.9
+numba==0.65.0
+flashinfer-python==0.6.13""")
+elif "vllm-project/vllm/releases/latest" in url:
+    print(json.dumps({"tag_name": os.environ.get("FAKE_VLLM_TAG", "v0.26.0")}))
+elif "NVIDIA/nccl/releases/latest" in url:
+    print(json.dumps({"tag_name": "v2.30.7-1"}))
+elif "astral-sh/uv/releases/latest" in url:
+    print(json.dumps({"tag_name": "0.11.31"}))
+elif "flashinfer-ai/flashinfer/releases/latest" in url:
+    print(json.dumps({"tag_name": "v0.6.13"}))
+elif "/pypi/triton/json" in url:
+    print(json.dumps({"info": {"version": "3.6.0"}}))
+elif "/pypi/nvidia-nvshmem-cu13/json" in url:
+    print(json.dumps({"info": {"version": "3.4.5"}}))
+elif "/pypi/" in url:
+    print(json.dumps({"info": {"version": "0.0.0"}}))
+elif "hub.docker.com" in url:
+    print(json.dumps({"images": [{
+        "architecture": "arm64",
+        "digest": "sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d7652024047020"
+    }]}))
+else:
+    print(f"unexpected URL: {url}", file=sys.stderr)
+    sys.exit(22)
+'''
+
+
+def setup_case(directory):
+    root = Path(directory) / "repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "locks").mkdir()
+    shutil.copy2(SOURCE_ROOT / "scripts" / "check-updates.sh", root / "scripts")
+    shutil.copy2(SOURCE_ROOT / "versions.env", root / "versions.env")
+    shutil.copy2(
+        SOURCE_ROOT / "locks" / "apt-sources.list",
+        root / "locks" / "apt-sources.list",
+    )
+    fake_bin = Path(directory) / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(FAKE_CURL)
+    fake_curl.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    return root, env
+
+
+def run_check(root, env, *arguments):
+    return subprocess.run(
+        ["bash", str(root / "scripts" / "check-updates.sh"), *arguments],
+        cwd=Path(root).parent,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def parse_env(path):
+    values = {}
+    for line in path.read_text().splitlines():
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value
+    return values
+
+
+def test_target_vllm_requirements_are_applied():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        result = run_check(root, env, "--update")
+        assert result.returncode == 0, result.stderr
+        values = parse_env(root / "versions.env")
+        assert values["VLLM_REF"] == "v0.26.0"
+        assert values["FLASHINFER_REF"] == "v9.3.0"
+        assert values["TORCH_VERSION"] == "9.9.0"
+        assert values["TORCHVISION_VERSION"] == "9.8.0"
+        assert values["TORCHAUDIO_VERSION"] == "9.7.0"
+        assert values["TVM_FFI_VERSION"] == "9.6.0"
+        assert values["TILELANG_VERSION"] == "9.5.0"
+        assert values["NUMBA_VERSION"] == "9.4.0"
+        assert (root / "versions.env").stat().st_mode & 0o777 == 0o644
+        assert "8 component(s) updated in versions.env" in result.stdout
+
+
+def test_dry_run_does_not_write_versions():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        before = (root / "versions.env").read_bytes()
+        result = run_check(root, env)
+        assert result.returncode == 0, result.stderr
+        assert "have updates available" in result.stdout
+        assert (root / "versions.env").read_bytes() == before
+
+
+def test_current_stack_reports_no_updates():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_VLLM_TAG"] = "v0.25.1"
+        result = run_check(root, env)
+        assert result.returncode == 0, result.stderr
+        assert "All components are current" in result.stdout
+
+
+def test_newer_prerelease_remains_the_dependency_target():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_VLLM_TAG"] = "v0.26.0"
+        versions = root / "versions.env"
+        text = versions.read_text().replace("VLLM_REF=v0.25.1", "VLLM_REF=v0.27.0rc1")
+        versions.write_text(text)
+        result = run_check(root, env)
+        assert result.returncode == 0, result.stderr
+        assert "pinned to newer pre-release" in result.stdout
+        assert "Fetching vLLM v0.27.0rc1 requirements" in result.stderr
+
+
+def test_apt_snapshot_bump_only_updates_snapshot():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_VLLM_TAG"] = "v0.25.1"
+        sources = root / "locks" / "apt-sources.list"
+        stale = sources.read_text().replace("20260714T000000Z", "20200101T000000Z")
+        stale = stale.replace("2026-07-14T00:00:00Z", "2020-01-01T00:00:00Z")
+        sources.write_text(stale)
+        versions_before = (root / "versions.env").read_bytes()
+
+        result = run_check(root, env, "--bump-apt-snapshot")
+        assert result.returncode == 0, result.stderr
+        today = datetime.now(timezone.utc).strftime("%Y%m%dT000000Z")
+        assert today in sources.read_text()
+        assert "snapshot advanced to today" in result.stdout
+        assert (root / "versions.env").read_bytes() == versions_before
+        assert sources.stat().st_mode & 0o777 == 0o644
+
+
+def test_requirement_fetch_failure_is_fatal():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_FAIL_RAW"] = "1"
+        result = run_check(root, env)
+        assert result.returncode != 0
+        assert "Could not fetch vLLM requirements" in result.stderr
+
+
+def test_invalid_vllm_release_tag_is_fatal():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_VLLM_TAG"] = "nightly"
+        result = run_check(root, env)
+        assert result.returncode != 0
+        assert "Could not compare vLLM versions" in result.stderr
+
+
+def test_upstream_failure_is_fatal():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_FAIL_ALL"] = "1"
+        result = run_check(root, env)
+        assert result.returncode != 0
+
+
+def test_mutating_modes_are_mutually_exclusive():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        result = run_check(root, env, "--update", "--bump-apt-snapshot")
+        assert result.returncode != 0
+        assert "Choose either" in result.stderr
+
+
+def main():
+    tests = [
+        test_target_vllm_requirements_are_applied,
+        test_dry_run_does_not_write_versions,
+        test_current_stack_reports_no_updates,
+        test_newer_prerelease_remains_the_dependency_target,
+        test_apt_snapshot_bump_only_updates_snapshot,
+        test_requirement_fetch_failure_is_fatal,
+        test_invalid_vllm_release_tag_is_fatal,
+        test_upstream_failure_is_fatal,
+        test_mutating_modes_are_mutually_exclusive,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} check-updates tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-pr-body-generation.py
+++ b/tests/test-pr-body-generation.py
@@ -266,8 +266,9 @@ SCENARIOS = [
         +BRAND_NEW_VAR=1.0.0
         """),
         {},
-        1,
+        2,
         [
+            "- **BRAND_NEW_VAR**: (added) -> 1.0.0",
             "- **vLLM**: v0.24.0 -> v0.25.1",
         ],
     ),

--- a/tests/test-release-notes-scenarios.py
+++ b/tests/test-release-notes-scenarios.py
@@ -8,50 +8,70 @@ Output is written to the path specified by OUTPUT_PATH env var, or
 defaults to /tmp/test-release-notes-output.md.
 """
 
-import hashlib, os, re, textwrap
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SOURCE_ROOT / "scripts"))
+from versions_diff import (
+    COMPONENTS,
+    LOCKFILES,
+    extract_apt_snapshot_date,
+    file_sha256,
+    parse_versions_env,
+)
+
+
+def test_release_notes_script_imports_shared_module():
+    """Every supported launch form must import the repository's shared module."""
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / "scripts" / "generate-release-notes.sh"
+    launch_commands = [
+        ["bash", "scripts/generate-release-notes.sh"],  # Exact CI invocation
+        ["./scripts/generate-release-notes.sh"],
+        ["bash", str(script)],
+    ]
+
+    with tempfile.TemporaryDirectory() as fake_module_dir:
+        # A conflicting module must not override the repository copy. This also
+        # verifies that an inherited REPO_ROOT cannot redirect imports.
+        fake_module = Path(fake_module_dir) / "versions_diff.py"
+        fake_module.write_text("raise RuntimeError('imported fake versions_diff')\n")
+
+        env = os.environ.copy()
+        env.update({
+            "TAG": "v-import-regression-gb10.0",
+            "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
+            "PYTHONPATH": fake_module_dir,
+            "REPO_ROOT": fake_module_dir,
+        })
+
+        for command in launch_commands:
+            result = subprocess.run(
+                command,
+                cwd=repo_root,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            assert result.returncode == 0, (
+                f"release-note command failed: {command}\n{result.stderr}"
+            )
+            assert "## v-import-regression-gb10.0" in result.stdout
+            assert "ModuleNotFoundError" not in result.stderr
+            assert "imported fake versions_diff" not in result.stderr
+
+
+test_release_notes_script_imports_shared_module()
 
 # ---------------------------------------------------------------------------
-# The exact logic from generate-release-notes.sh (extracted for testing)
+# Release-note scenario helpers
 # ---------------------------------------------------------------------------
-
-COMPONENTS = [
-    ("VLLM_REF", "vLLM"),
-    ("FLASHINFER_REF", "FlashInfer"),
-    ("NCCL_REF", "NCCL"),
-    ("TORCH_VERSION", "PyTorch"),
-    ("TORCHVISION_VERSION", "torchvision"),
-    ("TORCHAUDIO_VERSION", "torchaudio"),
-    ("TRITON_VERSION", "Triton"),
-    ("CUDA_BASE_IMAGE", "CUDA base"),
-    ("UV_VERSION", "uv"),
-    ("RAY_VERSION", "Ray"),
-    ("NVSHMEM_VERSION", "NVSHMEM"),
-    ("TVM_FFI_VERSION", "TVM-FFI"),
-    ("TILELANG_VERSION", "TileLang"),
-    ("NUMBA_VERSION", "Numba"),
-    ("FASTSAFETENSORS_VERSION", "fastsafetensors"),
-    ("INSTANTTENSOR_VERSION", "instanttensor"),
-    ("TORCH_CUDA_ARCH_LIST", "Target arch"),
-]
-
-LOCKFILES = [
-    ("locks/apt-packages.txt", "apt packages"),
-    ("locks/apt-sources.list", "apt snapshot"),
-    ("locks/python-bootstrap.txt", "python bootstrap lock"),
-    ("locks/python-build.txt", "python build lock"),
-    ("locks/python-runtime.txt", "python runtime lock"),
-]
-
-def parse_versions_env(text):
-    env = {}
-    for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        m = re.match(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)$', line)
-        if m:
-            env[m.group(1)] = m.group(2)
-    return env
 
 def get_previous_tag(current_tag, all_tags):
     """Simulated version: pass a sorted list of all tags (newest first)."""
@@ -60,17 +80,6 @@ def get_previous_tag(current_tag, all_tags):
         if idx + 1 < len(all_tags):
             return all_tags[idx + 1]
     return None
-
-def file_sha256(content):
-    """Return first 12 chars of SHA256 hex digest of content."""
-    return hashlib.sha256(content.encode()).hexdigest()[:12]
-
-def extract_apt_snapshot_date(content):
-    """Extract the snapshot timestamp from apt-sources.list, e.g. 20260714T000000Z."""
-    if not content:
-        return None
-    m = re.search(r'snapshot\.ubuntu\.com/ubuntu/(\d{8}T\d{6}Z)', content)
-    return m.group(1) if m else None
 
 def get_changed_section(current_tag, current_env, prev_tag, prev_env,
                         lockfile_map=None):

--- a/tests/test-script-integrations.py
+++ b/tests/test-script-integrations.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Integration tests for the real PR-body and release-note shell scripts."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+SOURCE_ROOT = Path(__file__).resolve().parent.parent
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def run(command, cwd, env=None, check=True):
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"Command failed ({result.returncode}): {command}\n{result.stderr}"
+        )
+    return result
+
+
+def copy_runtime(repo):
+    (repo / "scripts").mkdir()
+    (repo / "locks").mkdir()
+    for name in (
+        "generate-pr-body.sh",
+        "generate-release-notes.sh",
+        "versions_diff.py",
+    ):
+        shutil.copy2(SOURCE_ROOT / "scripts" / name, repo / "scripts" / name)
+    shutil.copy2(SOURCE_ROOT / "versions.env", repo / "versions.env")
+    for source in (SOURCE_ROOT / "locks").iterdir():
+        if source.is_file():
+            shutil.copy2(source, repo / "locks" / source.name)
+
+
+def init_repo(repo):
+    run(["git", "init", "-b", "main"], repo)
+    run(["git", "config", "user.name", "Integration Test"], repo)
+    run(["git", "config", "user.email", "test@example.invalid"], repo)
+
+
+def commit_all(repo, message):
+    run(["git", "add", "."], repo)
+    run(["git", "commit", "-m", message], repo)
+    return run(["git", "rev-parse", "HEAD"], repo).stdout.strip()
+
+
+def replace_env_value(path, key, value):
+    lines = path.read_text().splitlines()
+    updated = [f"{key}={value}" if line.startswith(f"{key}=") else line for line in lines]
+    path.write_text("\n".join(updated) + "\n")
+
+
+def test_pr_body_uses_worktree_and_fallback_base():
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory) / "repo"
+        repo.mkdir()
+        copy_runtime(repo)
+        init_repo(repo)
+        baseline = commit_all(repo, "baseline")
+        (repo / "README.test").write_text("second commit\n")
+        commit_all(repo, "head")
+        run(["git", "update-ref", "refs/remotes/origin/main", baseline], repo)
+
+        no_changes = run(
+            ["bash", str(repo / "scripts" / "generate-pr-body.sh")],
+            Path(directory),
+            check=False,
+        )
+        assert no_changes.returncode == 1
+        assert "detected no changes" in no_changes.stdout
+
+        replace_env_value(repo / "versions.env", "UV_VERSION", "99.0.0")
+        with (repo / "versions.env").open("a") as stream:
+            stream.write("BRAND_NEW_VAR=1.0.0\n")
+        versions = repo / "versions.env"
+        versions.write_text(
+            "\n".join(
+                line for line in versions.read_text().splitlines()
+                if not line.startswith("ACCELERATE_VERSION=")
+            ) + "\n"
+        )
+        (repo / "locks" / "python-runtime.txt").write_text("working tree lock\n")
+
+        result = run(
+            ["bash", str(repo / "scripts" / "generate-pr-body.sh")],
+            Path(directory),
+        )
+        assert "**uv**:" in result.stdout
+        assert "**BRAND_NEW_VAR**: (added) -> 1.0.0" in result.stdout
+        assert "**Accelerate**:" in result.stdout
+        assert "-> (removed)" in result.stdout
+        assert "**python runtime lock**:" in result.stdout
+
+        run(["git", "update-ref", "-d", "refs/remotes/origin/main"], repo)
+        fallback = run(
+            ["bash", str(repo / "scripts" / "generate-pr-body.sh")],
+            Path(directory),
+        )
+        assert "**uv**:" in fallback.stdout
+        assert "**python runtime lock**:" in fallback.stdout
+
+        (repo / "locks" / "apt-packages.txt").unlink()
+        missing_lock = run(
+            ["bash", str(repo / "scripts" / "generate-pr-body.sh")],
+            Path(directory),
+        )
+        assert "**apt packages**:" in missing_lock.stdout
+        assert "-> (missing)" in missing_lock.stdout
+
+
+def test_release_notes_compare_real_tags_and_lockfiles():
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory) / "repo"
+        repo.mkdir()
+        copy_runtime(repo)
+        init_repo(repo)
+
+        replace_env_value(repo / "versions.env", "UV_VERSION", "0.0.1")
+        (repo / "locks" / "python-runtime.txt").write_text("old lock\n")
+        commit_all(repo, "previous release")
+        run(["git", "tag", "v0.1.0-gb10.0"], repo)
+
+        shutil.copy2(SOURCE_ROOT / "versions.env", repo / "versions.env")
+        shutil.copy2(
+            SOURCE_ROOT / "locks" / "python-runtime.txt",
+            repo / "locks" / "python-runtime.txt",
+        )
+        current_sha = commit_all(repo, "current release")
+        run(["git", "tag", "v0.2.0-gb10.0"], repo)
+
+        env = os.environ.copy()
+        env.update({"TAG": "v0.2.0-gb10.0", "GITHUB_SHA": current_sha})
+        result = run(
+            ["bash", str(repo / "scripts" / "generate-release-notes.sh")],
+            Path(directory),
+            env=env,
+        )
+        assert "Changed components (vs v0.1.0-gb10.0)" in result.stdout
+        assert "**uv**: 0.0.1 ->" in result.stdout
+        assert "**python runtime lock**:" in result.stdout
+        assert f"commit/{current_sha}" in result.stdout
+
+
+def main():
+    tests = [
+        test_pr_body_uses_worktree_and_fallback_base,
+        test_release_notes_compare_real_tags_and_lockfiles,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} script integration tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- align FlashInfer and other coupled dependency pins with the target vLLM release
- preserve newer vLLM prerelease pins and fail clearly on invalid tags or upstream request failures
- generate PR bodies from the working tree with added, removed, changed, and missing-file handling
- make release-note generation repository-relative and fetch full tag history in release jobs
- propagate update-check failures instead of reporting them as no updates
- add mocked upstream tests and real temporary-Git-repository integration coverage

## Root cause

The automation mixed current and target vLLM requirement files, used embedded Python path assumptions that fail when reading from standard input, and relied on Git state that was not available in shallow release checkouts. Existing tests reproduced portions of the implementation instead of executing the real scripts, so CI-only path, tag, and working-tree failures were not covered.

## Impact

Dependency update PRs now carry a consistent target stack, release notes can compare against the previous tag, PR bodies include the actual pending working-tree changes, and upstream failures stop the workflow instead of being silently treated as no updates.

## Validation

- release-note scenarios and Markdown structure checks
- 9 mocked `check-updates.sh` tests
- 101 PR-body and shared-diff checks
- 2 real-script integration tests using temporary Git repositories
- 16 duplicate-PR checks
- Bash syntax validation for all scripts and tests
- ShellCheck for changed scripts
- actionlint for changed workflows
- Python compilation
- `git diff --check`