### PR TITLE
fix(release-monitor): create dependency PRs reliably

### DIFF
--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -79,7 +79,7 @@ jobs:
 
           case "$result" in
             0) echo "skip-pr=true" >> "$GITHUB_OUTPUT" ;;
-            1) echo "skip-pr=false" >> "$GITHUB_OUTPUT" ;;
+            10) echo "skip-pr=false" >> "$GITHUB_OUTPUT" ;;
             *)
               echo "Duplicate PR check failed with exit code $result" >&2
               exit "$result"

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -72,11 +72,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_MONITOR_PAT }}
         run: |
-          if scripts/check-duplicate-pr.py; then
-            echo "skip-pr=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip-pr=true" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          python3 scripts/check-duplicate-pr.py
+          result=$?
+          set -e
+
+          case "$result" in
+            0) echo "skip-pr=true" >> "$GITHUB_OUTPUT" ;;
+            1) echo "skip-pr=false" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "Duplicate PR check failed with exit code $result" >&2
+              exit "$result"
+              ;;
+          esac
 
       - name: Build PR body
         if: steps.changes.outputs.has-changes == 'true' && steps.existing-pr.outputs.skip-pr == 'false'

--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -2,7 +2,8 @@
 """
 Check if an open deps/bump PR already exists with identical versions.env changes.
 
-Returns exit code 0 (skip) or 1 (proceed) and prints a user-facing message.
+Returns exit code 0 (skip), 1 (proceed), or 2 (error) and prints a
+user-facing message.
 
 Usage:
   scripts/check-duplicate-pr.py
@@ -14,6 +15,7 @@ Exit codes:
   0 - Skip: an existing open PR already has the same versions.env changes
       (or no changes to versions.env in working tree)
   1 - Proceed: no matching PR found, caller should create a new one
+  2 - Error: the duplicate check could not be completed reliably
 """
 
 import json
@@ -98,6 +100,10 @@ def check_for_duplicate():
         ],
         check=False,
     )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"gh exited with code {result.returncode}"
+        raise RuntimeError(f"Could not list open dependency PRs: {detail}")
+
     prs_text = result.stdout.strip()
     if not prs_text:
         print("No open deps/bump PRs by this actor")
@@ -150,5 +156,9 @@ def check_for_duplicate():
 
 
 if __name__ == "__main__":
-    should_skip = check_for_duplicate()
+    try:
+        should_skip = check_for_duplicate()
+    except (json.JSONDecodeError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"Duplicate PR check failed: {error}", file=sys.stderr)
+        sys.exit(2)
     sys.exit(0 if should_skip else 1)

--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -2,7 +2,7 @@
 """
 Check if an open deps/bump PR already exists with identical versions.env changes.
 
-Returns exit code 0 (skip), 1 (proceed), or 2 (error) and prints a
+Returns exit code 0 (skip), 10 (proceed), or 2 (known error) and prints a
 user-facing message.
 
 Usage:
@@ -14,8 +14,11 @@ Environment:
 Exit codes:
   0 - Skip: an existing open PR already has the same versions.env changes
       (or no changes to versions.env in working tree)
-  1 - Proceed: no matching PR found, caller should create a new one
+ 10 - Proceed: no matching PR found, caller should create a new one
   2 - Error: the duplicate check could not be completed reliably
+
+All other nonzero exit codes are unexpected errors and must also fail the
+workflow.
 """
 
 import json
@@ -161,4 +164,4 @@ if __name__ == "__main__":
     except (json.JSONDecodeError, RuntimeError, subprocess.CalledProcessError) as error:
         print(f"Duplicate PR check failed: {error}", file=sys.stderr)
         sys.exit(2)
-    sys.exit(0 if should_skip else 1)
+    sys.exit(0 if should_skip else 10)

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -16,9 +16,10 @@ Scenario coverage:
   - Multiple PRs, second one matches (skip)
   - Multiple PRs, all match (skip - first match short-circuits)
   - gh returns single object not array (skip)
-  - gh pr list errors/network issue (proceed - fails open)
+  - gh pr list errors/network issue (error)
   - gh returns empty array (proceed)
-  - git fetch fails (proceed - fetch failure shouldn't block)
+  - git fetch fails (error)
+  - Workflow invokes the script through Python and maps all exit codes correctly
   - Branch has only GB10_BUILD change vs main, working tree has UV (proceed)
   - Working tree has only GB10_BUILD, branch has substantive vs main (skip)
 """
@@ -208,8 +209,9 @@ if __name__ == "__main__":
             "",
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {},
-             "fetch_exit": 0},
-            1,  # proceed (fails open)
+             "fetch_exit": 0,
+             "gh_exit": 1},
+            2,  # error (the duplicate check was inconclusive)
         ),
         (
             "gh returns empty array (no matching PRs)",
@@ -225,7 +227,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {},
              "fetch_exit": 1},  # fetch fails
-            1,  # proceed (fetch failure shouldn't block)
+            2,  # error (the duplicate check was inconclusive)
         ),
         (
             "Branch has only GB10_BUILD change vs main, working tree has UV",
@@ -256,6 +258,7 @@ if __name__ == "__main__":
             working_diff = fake_git_behaviors["working_diff"]
             branch_diffs_vs_main = fake_git_behaviors.get("branch_diffs_vs_main", {})
             fetch_exit = fake_git_behaviors.get("fetch_exit", 0)
+            gh_exit = fake_git_behaviors.get("gh_exit", 0)
 
             # Create mock gh script
             mock_gh = os.path.join(tmpdir, "gh")
@@ -263,8 +266,7 @@ if __name__ == "__main__":
                 f.write("#!/usr/bin/env bash\n")
                 if fake_gh_stdout:
                     f.write(f'cat << \'ENDJSON\'\n{fake_gh_stdout}\nENDJSON\n')
-                else:
-                    f.write("exit 0\n")
+                f.write(f"exit {gh_exit}\n")
             os.chmod(mock_gh, 0o755)
 
             # Create mock git script
@@ -333,6 +335,30 @@ if __name__ == "__main__":
                 print(f"  {line}")
 
         print()
+
+    workflow_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", ".github", "workflows",
+                     "monitor-upstream-releases.yaml")
+    )
+    with open(workflow_path) as workflow_file:
+        workflow = workflow_file.read()
+
+    check(
+        "python3 scripts/check-duplicate-pr.py" in workflow,
+        "Workflow must invoke the Python script without relying on its executable bit",
+    )
+    check(
+        '0) echo "skip-pr=true"' in workflow,
+        "Workflow must skip PR creation when the script reports a duplicate",
+    )
+    check(
+        '1) echo "skip-pr=false"' in workflow,
+        "Workflow must proceed when the script reports no duplicate",
+    )
+    check(
+        'exit "$result"' in workflow,
+        "Workflow must fail instead of skipping when the duplicate check errors",
+    )
 
     print(f"FAIL: {failed}")
     if failed:

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
             "Substantive changes (UV_VERSION + GB10_BUILD), no open PRs",
             "",
             {"working_diff": UV_AND_GB10_DIFF, "branch_diffs_vs_main": {}, "fetch_exit": 0},
-            1,  # proceed
+            10,  # proceed
         ),
         (
             "Single PR with matching substantive changes (UV_VERSION + GB10_BUILD)",
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {"deps/bump-42": GB10_ONLY_DIFF},
              "fetch_exit": 0},
-            1,  # proceed (branch has no substantive change vs main)
+            10,  # proceed (branch has no substantive change vs main)
         ),
         (
             "Single PR with different substantive changes (VLLM_REF vs UV_VERSION)",
@@ -162,7 +162,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {"deps/bump-42": VLLM_AND_GB10_DIFF},
              "fetch_exit": 0},
-            1,  # proceed (different variables changed)
+            10,  # proceed (different variables changed)
         ),
         (
             "Single PR with same UV but different GB10_BUILD (same substantive)",
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {"deps/bump-41": VLLM_AND_GB10_DIFF, "deps/bump-42": VLLM_AND_GB10_DIFF},
              "fetch_exit": 0},
-            1,  # proceed
+            10,  # proceed
         ),
         (
             "Multiple PRs, second one matches",
@@ -219,7 +219,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {},
              "fetch_exit": 0},
-            1,  # proceed
+            10,  # proceed
         ),
         (
             "git fetch fails for the PR branch (rate limited)",
@@ -235,7 +235,7 @@ if __name__ == "__main__":
             {"working_diff": UV_AND_GB10_DIFF,
              "branch_diffs_vs_main": {"deps/bump-42": GB10_ONLY_DIFF},
              "fetch_exit": 0},
-            1,  # proceed (different substantive content)
+            10,  # proceed (different substantive content)
         ),
         (
             "Working tree has only GB10_BUILD, branch has substantive vs main",
@@ -352,8 +352,12 @@ if __name__ == "__main__":
         "Workflow must skip PR creation when the script reports a duplicate",
     )
     check(
-        '1) echo "skip-pr=false"' in workflow,
+        '10) echo "skip-pr=false"' in workflow,
         "Workflow must proceed when the script reports no duplicate",
+    )
+    check(
+        '1) echo "skip-pr=false"' not in workflow,
+        "Workflow must not treat a generic script failure as permission to proceed",
     )
     check(
         'exit "$result"' in workflow,


### PR DESCRIPTION
## Summary

- invoke the duplicate PR checker through Python so its file mode cannot block execution
- map duplicate, proceed, and error exit codes correctly
- fail visibly when GitHub or branch inspection is inconclusive
- add regression coverage for workflow exit handling

## Validation

- `python3 tests/test-release-notes-scenarios.py`
- `python3 tests/test-check-updates.py`
- `python3 tests/test-pr-body-generation.py`
- `python3 tests/test-script-integrations.py`
- `python3 tests/test-check-duplicate-pr.py`
- `python3 -m py_compile scripts/check-duplicate-pr.py tests/test-check-duplicate-pr.py`
- `git diff --check`