### PR TITLE
fix(ci): make trusted bump push portable

### DIFF
--- a/.github/workflows/run-bump.yaml
+++ b/.github/workflows/run-bump.yaml
@@ -189,7 +189,8 @@ jobs:
               'esac' > "$ASKPASS"
             chmod 700 "$ASKPASS"
             GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
-              git push origin "HEAD:refs/heads/$APPROVED_BRANCH"
+              git -c core.hooksPath=/dev/null \
+              push origin "HEAD:refs/heads/$APPROVED_BRANCH"
           fi
 
       - name: Remove trusted generator worktree

--- a/.github/workflows/run-bump.yaml
+++ b/.github/workflows/run-bump.yaml
@@ -176,8 +176,20 @@ jobs:
           if [[ "$(git rev-parse HEAD)" = "$APPROVED_SHA" ]]; then
             echo "Nothing to push."
           else
-            gh auth setup-git
-            git push origin "HEAD:refs/heads/$APPROVED_BRANCH"
+            ASKPASS=$(mktemp "${RUNNER_TEMP}/git-askpass-XXXXXX")
+            trap 'rm -f "$ASKPASS"' EXIT
+            # Preserve these variables for expansion inside the helper.
+            # shellcheck disable=SC2016
+            printf '%s\n' \
+              '#!/bin/sh' \
+              'case "$1" in' \
+              '  *Username*) printf "%s\n" "x-access-token" ;;' \
+              '  *Password*) printf "%s\n" "$GH_TOKEN" ;;' \
+              '  *) exit 1 ;;' \
+              'esac' > "$ASKPASS"
+            chmod 700 "$ASKPASS"
+            GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 \
+              git push origin "HEAD:refs/heads/$APPROVED_BRANCH"
           fi
 
       - name: Remove trusted generator worktree

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -60,6 +60,9 @@ jobs:
       - name: Validate versions.env security rules
         run: python3 tests/test-versions-env.py
 
+      - name: Validate GB10 build-number allocation
+        run: python3 tests/test-compute-gb10-build.py
+
       - name: Validate apt input security rules
         run: python3 tests/test-apt-inputs.py
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -65,6 +65,7 @@ _MAIN_VERSIONS="$(git show origin/main:versions.env 2>/dev/null \
 _main_get() { printf '%s\n' "${_MAIN_VERSIONS}" | grep "^$1=" | head -1 | cut -d= -f2-; }
 
 OLD_NCCL_COMMIT="$(_main_get NCCL_COMMIT)"
+OLD_VLLM_REF="$(_main_get VLLM_REF)"
 OLD_VLLM_COMMIT="$(_main_get VLLM_COMMIT)"
 OLD_FLASHINFER_COMMIT="$(_main_get FLASHINFER_COMMIT)"
 OLD_CUDA_BASE_DIGEST="$(_main_get CUDA_BASE_DIGEST)"
@@ -174,23 +175,40 @@ log "  CUDA_BASE_DIGEST=${CUDA_BASE_DIGEST}"
 # ---------------------------------------------------------------------------
 # 5. Compute GB10_BUILD
 # Rule: reset to 0 when VLLM_REF changes.
-#       Increment by 1 when any other pinned input changes with the same VLLM_REF.
+#       Increment by 1 when any other pinned input changes with the same VLLM_REF,
+#       including when upstream moves an existing tag to a different commit.
 # ---------------------------------------------------------------------------
-if [[ "${VLLM_COMMIT}" != "${OLD_VLLM_COMMIT}" ]]; then
-  GB10_BUILD=0
-  log "VLLM_COMMIT changed -> GB10_BUILD reset to 0"
-elif [[ "${NCCL_COMMIT}"         != "${OLD_NCCL_COMMIT}"         ||
-        "${FLASHINFER_COMMIT}"   != "${OLD_FLASHINFER_COMMIT}"   ||
-        "${CUDA_BASE_DIGEST}"    != "${OLD_CUDA_BASE_DIGEST}"    ||
-        "${RAY_VERSION}"         != "${OLD_RAY_VERSION}"         ||
-        "${UV_VERSION}"          != "${OLD_UV_VERSION}"          ||
-        "${TORCH_VERSION}"       != "${OLD_TORCH_VERSION}"       ||
-        "${TORCHVISION_VERSION}" != "${OLD_TORCHVISION_VERSION}" ||
-        "${QUACK_KERNELS_VERSION}" != "${OLD_QUACK_KERNELS_VERSION}" ||
-        "${DOCKERFILE_HASH}"     != "${OLD_DOCKERFILE_HASH}"     ||
-        "${APT_SOURCES_HASH}"    != "${OLD_APT_SOURCES_HASH}"    ]]; then
-  GB10_BUILD=$(( OLD_GB10_BUILD + 1 ))
-  log "Non-vLLM input changed -> GB10_BUILD incremented to ${GB10_BUILD}"
+BUILD_INPUT_CHANGED=0
+if [[ "${VLLM_COMMIT}"           != "${OLD_VLLM_COMMIT}"           ||
+      "${NCCL_COMMIT}"           != "${OLD_NCCL_COMMIT}"           ||
+      "${FLASHINFER_COMMIT}"     != "${OLD_FLASHINFER_COMMIT}"     ||
+      "${CUDA_BASE_DIGEST}"      != "${OLD_CUDA_BASE_DIGEST}"      ||
+      "${RAY_VERSION}"           != "${OLD_RAY_VERSION}"           ||
+      "${UV_VERSION}"            != "${OLD_UV_VERSION}"            ||
+      "${TORCH_VERSION}"         != "${OLD_TORCH_VERSION}"         ||
+      "${TORCHVISION_VERSION}"   != "${OLD_TORCHVISION_VERSION}"   ||
+      "${QUACK_KERNELS_VERSION}" != "${OLD_QUACK_KERNELS_VERSION}" ||
+      "${DOCKERFILE_HASH}"       != "${OLD_DOCKERFILE_HASH}"       ||
+      "${APT_SOURCES_HASH}"      != "${OLD_APT_SOURCES_HASH}" ]]; then
+  BUILD_INPUT_CHANGED=1
+fi
+
+BUILD_ARGS=(
+  --old-vllm-ref "${OLD_VLLM_REF}"
+  --new-vllm-ref "${VLLM_REF}"
+  --old-build "${OLD_GB10_BUILD}"
+)
+if [[ "${BUILD_INPUT_CHANGED}" -eq 1 ]]; then
+  BUILD_ARGS+=(--build-input-changed)
+fi
+GB10_BUILD="$(
+  python3 "${REPO_ROOT}/scripts/compute-gb10-build.py" "${BUILD_ARGS[@]}"
+)"
+
+if [[ "${VLLM_REF}" != "${OLD_VLLM_REF}" ]]; then
+  log "VLLM_REF changed -> GB10_BUILD reset to ${GB10_BUILD}"
+elif [[ "${BUILD_INPUT_CHANGED}" -eq 1 ]]; then
+  log "Build input changed -> GB10_BUILD incremented to ${GB10_BUILD}"
 else
   log "No pinned inputs changed - GB10_BUILD stays at ${GB10_BUILD}"
 fi
@@ -263,8 +281,9 @@ TMP_BUILD=$(mktemp /tmp/vllm-gb10-build-XXXXX.in)
 # shellcheck disable=SC2064
 trap "rm -f '${TMP_BUILD}'" EXIT
 
-# PyTorch stack (exact versions from cu130 index)
-cat >> "${TMP_BUILD}" <<REQS
+# PyTorch stack, vLLM build requirements, and FlashInfer build dependencies.
+{
+cat <<REQS
 torch==${TORCH_VERSION}
 torchvision==${TORCHVISION_VERSION}
 torchaudio==${TORCHAUDIO_VERSION}
@@ -272,8 +291,8 @@ triton==${TRITON_VERSION}
 REQS
 
 # vLLM build requirements at VLLM_COMMIT (try both possible paths)
-_fetch_vllm_req "requirements/build.txt"      >> "${TMP_BUILD}"
-_fetch_vllm_req "requirements/build/cuda.txt" >> "${TMP_BUILD}"
+_fetch_vllm_req "requirements/build.txt"
+_fetch_vllm_req "requirements/build/cuda.txt"
 
 # FlashInfer [build-system].requires from pyproject.toml at FLASHINFER_COMMIT
 # Only extract the 'requires' array - not build-backend or backend-path values.
@@ -316,7 +335,8 @@ for relpath in pyproject_paths:
         extract_build_requires(content)
     except Exception as e:
         print(f'# WARNING: could not fetch FlashInfer {relpath}: {e}', file=sys.stderr)
-" >> "${TMP_BUILD}"
+"
+} >> "${TMP_BUILD}"
 
 uv pip compile \
   --generate-hashes \
@@ -345,13 +365,14 @@ TMP_RUNTIME=$(mktemp /tmp/vllm-gb10-runtime-XXXXX.in)
 # shellcheck disable=SC2064
 trap "rm -f '${TMP_RUNTIME}'" EXIT
 
+{
 # vLLM runtime requirements at VLLM_COMMIT
-_fetch_vllm_req "requirements/common.txt" >> "${TMP_RUNTIME}"
-_fetch_vllm_req "requirements/cuda.txt"   >> "${TMP_RUNTIME}"
+_fetch_vllm_req "requirements/common.txt"
+_fetch_vllm_req "requirements/cuda.txt"
 
 # Explicit seed versions from versions.env.
 # These supplement or override what vLLM's requirements declare.
-cat >> "${TMP_RUNTIME}" <<REQS
+cat <<REQS
 ray[default]==${RAY_VERSION}
 fastsafetensors>=${FASTSAFETENSORS_VERSION}
 instanttensor==${INSTANTTENSOR_VERSION}
@@ -363,6 +384,7 @@ bitsandbytes==${BITSANDBYTES_VERSION}
 accelerate==${ACCELERATE_VERSION}
 quack-kernels==${QUACK_KERNELS_VERSION}
 REQS
+} >> "${TMP_RUNTIME}"
 
 uv pip compile \
   --generate-hashes \

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -56,6 +56,8 @@ log "  VLLM_REF=${VLLM_REF}"
 log "  FLASHINFER_REF=${FLASHINFER_REF}"
 log "  NCCL_REF=${NCCL_REF}"
 
+REVIEWED_VLLM_COMMIT="${VLLM_COMMIT}"
+
 # ---------------------------------------------------------------------------
 # 2. Snapshot old values for GB10_BUILD change detection
 # ---------------------------------------------------------------------------
@@ -178,9 +180,8 @@ log "  CUDA_BASE_DIGEST=${CUDA_BASE_DIGEST}"
 #       Increment by 1 when any other pinned input changes with the same VLLM_REF,
 #       including when upstream moves an existing tag to a different commit.
 # ---------------------------------------------------------------------------
-BUILD_INPUT_CHANGED=0
-if [[ "${VLLM_COMMIT}"           != "${OLD_VLLM_COMMIT}"           ||
-      "${NCCL_COMMIT}"           != "${OLD_NCCL_COMMIT}"           ||
+OTHER_INPUT_CHANGED=0
+if [[ "${NCCL_COMMIT}"           != "${OLD_NCCL_COMMIT}"           ||
       "${FLASHINFER_COMMIT}"     != "${OLD_FLASHINFER_COMMIT}"     ||
       "${CUDA_BASE_DIGEST}"      != "${OLD_CUDA_BASE_DIGEST}"      ||
       "${RAY_VERSION}"           != "${OLD_RAY_VERSION}"           ||
@@ -190,16 +191,19 @@ if [[ "${VLLM_COMMIT}"           != "${OLD_VLLM_COMMIT}"           ||
       "${QUACK_KERNELS_VERSION}" != "${OLD_QUACK_KERNELS_VERSION}" ||
       "${DOCKERFILE_HASH}"       != "${OLD_DOCKERFILE_HASH}"       ||
       "${APT_SOURCES_HASH}"      != "${OLD_APT_SOURCES_HASH}" ]]; then
-  BUILD_INPUT_CHANGED=1
+  OTHER_INPUT_CHANGED=1
 fi
 
 BUILD_ARGS=(
   --old-vllm-ref "${OLD_VLLM_REF}"
   --new-vllm-ref "${VLLM_REF}"
+  --old-vllm-commit "${OLD_VLLM_COMMIT}"
+  --reviewed-vllm-commit "${REVIEWED_VLLM_COMMIT}"
+  --resolved-vllm-commit "${VLLM_COMMIT}"
   --old-build "${OLD_GB10_BUILD}"
 )
-if [[ "${BUILD_INPUT_CHANGED}" -eq 1 ]]; then
-  BUILD_ARGS+=(--build-input-changed)
+if [[ "${OTHER_INPUT_CHANGED}" -eq 1 ]]; then
+  BUILD_ARGS+=(--other-input-changed)
 fi
 GB10_BUILD="$(
   python3 "${REPO_ROOT}/scripts/compute-gb10-build.py" "${BUILD_ARGS[@]}"
@@ -207,7 +211,8 @@ GB10_BUILD="$(
 
 if [[ "${VLLM_REF}" != "${OLD_VLLM_REF}" ]]; then
   log "VLLM_REF changed -> GB10_BUILD reset to ${GB10_BUILD}"
-elif [[ "${BUILD_INPUT_CHANGED}" -eq 1 ]]; then
+elif [[ "${VLLM_COMMIT}" != "${OLD_VLLM_COMMIT}" ||
+        "${OTHER_INPUT_CHANGED}" -eq 1 ]]; then
   log "Build input changed -> GB10_BUILD incremented to ${GB10_BUILD}"
 else
   log "No pinned inputs changed - GB10_BUILD stays at ${GB10_BUILD}"
@@ -281,9 +286,8 @@ TMP_BUILD=$(mktemp /tmp/vllm-gb10-build-XXXXX.in)
 # shellcheck disable=SC2064
 trap "rm -f '${TMP_BUILD}'" EXIT
 
-# PyTorch stack, vLLM build requirements, and FlashInfer build dependencies.
-{
-cat <<REQS
+# PyTorch stack (exact versions from cu130 index)
+cat >> "${TMP_BUILD}" <<REQS
 torch==${TORCH_VERSION}
 torchvision==${TORCHVISION_VERSION}
 torchaudio==${TORCHAUDIO_VERSION}
@@ -291,8 +295,8 @@ triton==${TRITON_VERSION}
 REQS
 
 # vLLM build requirements at VLLM_COMMIT (try both possible paths)
-_fetch_vllm_req "requirements/build.txt"
-_fetch_vllm_req "requirements/build/cuda.txt"
+_fetch_vllm_req "requirements/build.txt"      >> "${TMP_BUILD}"
+_fetch_vllm_req "requirements/build/cuda.txt" >> "${TMP_BUILD}"
 
 # FlashInfer [build-system].requires from pyproject.toml at FLASHINFER_COMMIT
 # Only extract the 'requires' array - not build-backend or backend-path values.
@@ -335,8 +339,7 @@ for relpath in pyproject_paths:
         extract_build_requires(content)
     except Exception as e:
         print(f'# WARNING: could not fetch FlashInfer {relpath}: {e}', file=sys.stderr)
-"
-} >> "${TMP_BUILD}"
+" >> "${TMP_BUILD}"
 
 uv pip compile \
   --generate-hashes \
@@ -365,14 +368,13 @@ TMP_RUNTIME=$(mktemp /tmp/vllm-gb10-runtime-XXXXX.in)
 # shellcheck disable=SC2064
 trap "rm -f '${TMP_RUNTIME}'" EXIT
 
-{
 # vLLM runtime requirements at VLLM_COMMIT
-_fetch_vllm_req "requirements/common.txt"
-_fetch_vllm_req "requirements/cuda.txt"
+_fetch_vllm_req "requirements/common.txt" >> "${TMP_RUNTIME}"
+_fetch_vllm_req "requirements/cuda.txt"   >> "${TMP_RUNTIME}"
 
 # Explicit seed versions from versions.env.
 # These supplement or override what vLLM's requirements declare.
-cat <<REQS
+cat >> "${TMP_RUNTIME}" <<REQS
 ray[default]==${RAY_VERSION}
 fastsafetensors>=${FASTSAFETENSORS_VERSION}
 instanttensor==${INSTANTTENSOR_VERSION}
@@ -384,7 +386,6 @@ bitsandbytes==${BITSANDBYTES_VERSION}
 accelerate==${ACCELERATE_VERSION}
 quack-kernels==${QUACK_KERNELS_VERSION}
 REQS
-} >> "${TMP_RUNTIME}"
 
 uv pip compile \
   --generate-hashes \

--- a/scripts/compute-gb10-build.py
+++ b/scripts/compute-gb10-build.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Compute the GB10 build number without reusing an immutable image tag."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def compute_build_number(
+    old_vllm_ref: str,
+    new_vllm_ref: str,
+    old_build: int,
+    build_input_changed: bool,
+) -> int:
+    """Reset for a new release ref, otherwise advance for changed inputs."""
+    if new_vllm_ref != old_vllm_ref:
+        return 0
+    if build_input_changed:
+        return old_build + 1
+    return old_build
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--old-vllm-ref", required=True)
+    parser.add_argument("--new-vllm-ref", required=True)
+    parser.add_argument("--old-build", required=True, type=int)
+    parser.add_argument("--build-input-changed", action="store_true")
+    args = parser.parse_args()
+
+    print(
+        compute_build_number(
+            args.old_vllm_ref,
+            args.new_vllm_ref,
+            args.old_build,
+            args.build_input_changed,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute-gb10-build.py
+++ b/scripts/compute-gb10-build.py
@@ -6,16 +6,33 @@ from __future__ import annotations
 import argparse
 
 
+class BuildPolicyError(ValueError):
+    """Raised when reviewed inputs do not authorize a build-number decision."""
+
+
 def compute_build_number(
     old_vllm_ref: str,
     new_vllm_ref: str,
+    old_vllm_commit: str,
+    reviewed_vllm_commit: str,
+    resolved_vllm_commit: str,
     old_build: int,
-    build_input_changed: bool,
+    other_input_changed: bool,
 ) -> int:
-    """Reset for a new release ref, otherwise advance for changed inputs."""
+    """Validate ref movement, then allocate the next immutable image tag."""
+    if (
+        new_vllm_ref == old_vllm_ref
+        and resolved_vllm_commit != old_vllm_commit
+        and reviewed_vllm_commit != resolved_vllm_commit
+    ):
+        raise BuildPolicyError(
+            f"{new_vllm_ref} moved from {old_vllm_commit} to "
+            f"{resolved_vllm_commit}; update VLLM_COMMIT to the new SHA "
+            "and review that exact commit before rerunning bump.sh"
+        )
     if new_vllm_ref != old_vllm_ref:
         return 0
-    if build_input_changed:
+    if resolved_vllm_commit != old_vllm_commit or other_input_changed:
         return old_build + 1
     return old_build
 
@@ -24,18 +41,26 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--old-vllm-ref", required=True)
     parser.add_argument("--new-vllm-ref", required=True)
+    parser.add_argument("--old-vllm-commit", required=True)
+    parser.add_argument("--reviewed-vllm-commit", required=True)
+    parser.add_argument("--resolved-vllm-commit", required=True)
     parser.add_argument("--old-build", required=True, type=int)
-    parser.add_argument("--build-input-changed", action="store_true")
+    parser.add_argument("--other-input-changed", action="store_true")
     args = parser.parse_args()
 
-    print(
-        compute_build_number(
-            args.old_vllm_ref,
-            args.new_vllm_ref,
-            args.old_build,
-            args.build_input_changed,
+    try:
+        build_number = compute_build_number(
+            old_vllm_ref=args.old_vllm_ref,
+            new_vllm_ref=args.new_vllm_ref,
+            old_vllm_commit=args.old_vllm_commit,
+            reviewed_vllm_commit=args.reviewed_vllm_commit,
+            resolved_vllm_commit=args.resolved_vllm_commit,
+            old_build=args.old_build,
+            other_input_changed=args.other_input_changed,
         )
-    )
+    except BuildPolicyError as error:
+        parser.error(str(error))
+    print(build_number)
 
 
 if __name__ == "__main__":

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -70,6 +70,11 @@ def test_bump_workflow_preserves_approval_boundary():
     assert workflow.count("git ls-remote --exit-code origin") == 2
     assert "git checkout --detach \"$APPROVED_SHA\"" in workflow
     assert workflow.count("run: bash scripts/bump.sh") == 1
+    assert workflow.count("core.hooksPath=/dev/null") == 2
+    assert (
+        'git -c core.hooksPath=/dev/null \\\n'
+        '              push origin "HEAD:refs/heads/$APPROVED_BRANCH"'
+    ) in workflow
     assert "gh auth setup-git" not in workflow
     assert "x-access-token:${GH_TOKEN}" not in workflow
 

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -62,12 +62,16 @@ def test_bump_workflow_preserves_approval_boundary():
         "versions.env|locks/*",
         "find locks -type l",
         "core.hooksPath=/dev/null",
+        'GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0',
+        'trap \'rm -f "$ASKPASS"\' EXIT',
     )
     for control in required_controls:
         assert control in workflow, f"run-bump.yaml lost control: {control}"
     assert workflow.count("git ls-remote --exit-code origin") == 2
     assert "git checkout --detach \"$APPROVED_SHA\"" in workflow
     assert workflow.count("run: bash scripts/bump.sh") == 1
+    assert "gh auth setup-git" not in workflow
+    assert "x-access-token:${GH_TOKEN}" not in workflow
 
 
 def test_trusted_builds_checkout_the_exact_event_sha():

--- a/tests/test-compute-gb10-build.py
+++ b/tests/test-compute-gb10-build.py
@@ -12,29 +12,87 @@ assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
+OLD_COMMIT = "a" * 40
+NEW_COMMIT = "b" * 40
+
+
+def compute(
+    *,
+    old_ref="v0.26.0",
+    new_ref="v0.26.0",
+    old_commit=OLD_COMMIT,
+    reviewed_commit=OLD_COMMIT,
+    resolved_commit=OLD_COMMIT,
+    old_build=2,
+    other_changed=False,
+):
+    return MODULE.compute_build_number(
+        old_vllm_ref=old_ref,
+        new_vllm_ref=new_ref,
+        old_vllm_commit=old_commit,
+        reviewed_vllm_commit=reviewed_commit,
+        resolved_vllm_commit=resolved_commit,
+        old_build=old_build,
+        other_input_changed=other_changed,
+    )
+
 
 def test_new_vllm_ref_starts_new_build_series():
-    assert MODULE.compute_build_number("v0.25.0", "v0.26.0", 5, True) == 0
+    assert compute(
+        old_ref="v0.25.0",
+        new_ref="v0.26.0",
+        resolved_commit=NEW_COMMIT,
+        old_build=5,
+        other_changed=True,
+    ) == 0
 
 
-def test_moved_tag_advances_existing_build_series():
-    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, True) == 3
+def test_unreviewed_moved_tag_is_rejected():
+    try:
+        compute(resolved_commit=NEW_COMMIT)
+    except MODULE.BuildPolicyError as error:
+        assert "update VLLM_COMMIT" in str(error)
+        return
+    raise AssertionError("accepted an unreviewed moved vLLM tag")
+
+
+def test_reviewed_moved_tag_advances_existing_build_series():
+    assert compute(
+        reviewed_commit=NEW_COMMIT,
+        resolved_commit=NEW_COMMIT,
+    ) == 3
 
 
 def test_other_input_change_advances_existing_build_series():
-    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, True) == 3
+    assert compute(other_changed=True) == 3
 
 
 def test_no_change_preserves_build_number():
-    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, False) == 2
+    assert compute() == 2
+
+
+def test_bump_script_passes_reviewed_and_resolved_commits_to_policy():
+    bump = (ROOT / "scripts" / "bump.sh").read_text(encoding="utf-8")
+    for argument in (
+        '--old-vllm-commit "${OLD_VLLM_COMMIT}"',
+        '--reviewed-vllm-commit "${REVIEWED_VLLM_COMMIT}"',
+        '--resolved-vllm-commit "${VLLM_COMMIT}"',
+    ):
+        assert argument in bump
+    input_detection = bump.split("OTHER_INPUT_CHANGED=0", 1)[1].split(
+        "BUILD_ARGS=(", 1
+    )[0]
+    assert "VLLM_COMMIT" not in input_detection
 
 
 def main():
     tests = (
         test_new_vllm_ref_starts_new_build_series,
-        test_moved_tag_advances_existing_build_series,
+        test_unreviewed_moved_tag_is_rejected,
+        test_reviewed_moved_tag_advances_existing_build_series,
         test_other_input_change_advances_existing_build_series,
         test_no_change_preserves_build_number,
+        test_bump_script_passes_reviewed_and_resolved_commits_to_policy,
     )
     for test in tests:
         test()

--- a/tests/test-compute-gb10-build.py
+++ b/tests/test-compute-gb10-build.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Contract tests for immutable GB10 image-tag allocation."""
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "compute-gb10-build.py"
+SPEC = importlib.util.spec_from_file_location("compute_gb10_build", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_new_vllm_ref_starts_new_build_series():
+    assert MODULE.compute_build_number("v0.25.0", "v0.26.0", 5, True) == 0
+
+
+def test_moved_tag_advances_existing_build_series():
+    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, True) == 3
+
+
+def test_other_input_change_advances_existing_build_series():
+    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, True) == 3
+
+
+def test_no_change_preserves_build_number():
+    assert MODULE.compute_build_number("v0.26.0", "v0.26.0", 2, False) == 2
+
+
+def main():
+    tests = (
+        test_new_vllm_ref_starts_new_build_series,
+        test_moved_tag_advances_existing_build_series,
+        test_other_input_change_advances_existing_build_series,
+        test_no_change_preserves_build_number,
+    )
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} GB10 build-number tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- authenticate the final trusted bump push with a temporary `GIT_ASKPASS` helper instead of requiring GitHub CLI on the persistent runner
- disable Git hooks for both the generated commit and the token-bearing push
- reject same-ref vLLM tag movement unless the proposed `versions.env` already pins the exact newly resolved commit
- reset `GB10_BUILD` only when `VLLM_REF` changes
- increment the existing build series after a moved tag commit has been explicitly pinned and reviewed
- add hosted regression coverage for credential-boundary controls, retag authorization, policy wiring, and build-number allocation

## Context

[Run 30392001954](https://github.com/timothystewart6/vllm-gb10/actions/runs/30392001954/job/90385638384) generated a bump commit for #68, then failed because `gh` was not installed on the Spark runner.

The same run detected that upstream moved `v0.26.0` from `f2654939e69b4069b13977e9aef3e31d4dcaf051` to `568afb3a13806beb53bb2e6bd518269357b237c0`. The existing logic reset `GB10_BUILD` to 0 whenever the resolved commit changed, which would reuse the already allocated `v0.26.0-gb10.0` image tag.

The revised policy fails closed when an existing ref moves and the proposed input still contains the old commit. The workflow reports the new SHA and requires it to be added to `versions.env` and reviewed at the exact PR head before another dispatch. Once authorized, the same release ref advances from the main branch build number instead of reusing build 0.

This PR must merge before rerunning the trusted bump workflow for #68 because `run-bump.yaml` and `scripts/bump.sh` execute only from trusted `main`.

## Security

The checkout remains configured with `persist-credentials: false`. The workflow exposes `GITHUB_TOKEN` only to the final trusted push step through a temporary helper, does not place the token in the remote URL or repository configuration, disables Git hooks for the push, and removes the helper on step exit.

A same-ref vLLM commit change is rejected before requirements from the newly resolved commit are fetched and passed to the dependency resolver unless that exact commit was already present in the reviewed declarative input.

## Validation

- complete Python test suite, 102 checks
- 6 build-policy tests covering new refs, unreviewed retags, reviewed retags, ordinary changes, no-op behavior, and `bump.sh` policy wiring
- 9 privileged CI security-policy tests
- `actionlint .github/workflows/*.yaml`
- `shellcheck -S warning scripts/bump.sh`
- Python bytecode compilation
- `git diff --check`
- fresh security and feature review after remediation