### PR TITLE
fix(monitor): securely create PR from detached checkout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,5 @@
 /locks/ @timothystewart6
 /scripts/ @timothystewart6
 /tests/test-ci-security-policy.py @timothystewart6
+/tests/test-monitor-update-policy.py @timothystewart6
 /tests/test-versions-contract.py @timothystewart6

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -15,9 +15,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
+
+concurrency:
+  group: monitor-upstream-releases
+  cancel-in-progress: false
 
 jobs:
   check-deps:
@@ -113,5 +115,6 @@ jobs:
           title: 'chore(deps): bump upstream dependencies'
           body-path: /tmp/pr-body.md
           base: main
+          add-paths: versions.env
           branch: deps/bump-${{ github.run_number }}
           delete-branch: true

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -45,17 +45,28 @@ jobs:
       - name: Check for dependency updates
         id: check
         run: |
-          if ! scripts/check-updates.sh > /tmp/check-updates.log 2>&1; then
+          if ! scripts/check-updates.sh --update > /tmp/check-updates.log 2>&1; then
             cat /tmp/check-updates.log
             exit 1
           fi
           cat /tmp/check-updates.log
-          
-          if grep -q "have updates available" /tmp/check-updates.log; then
-            echo "has-update=true" >> "$GITHUB_OUTPUT"
-          else
+
+          if git diff --quiet -- versions.env; then
             echo "has-update=false" >> "$GITHUB_OUTPUT"
+          else
+            python3 scripts/validate-monitor-update.py \
+              <(git show HEAD:versions.env) versions.env
+            echo "has-update=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Upload update candidate
+        if: steps.check.outputs.has-update == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: release-monitor-versions-${{ github.run_id }}
+          path: versions.env
+          if-no-files-found: error
+          retention-days: 1
 
   create-pr:
     needs: check-deps
@@ -70,8 +81,17 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
-      - name: Update versions
-        run: scripts/check-updates.sh --update
+      - name: Download update candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-monitor-versions-${{ github.run_id }}
+          path: /tmp/release-monitor
+
+      - name: Validate and apply update candidate
+        run: |
+          python3 scripts/validate-monitor-update.py \
+            versions.env /tmp/release-monitor/versions.env
+          install -m 0644 /tmp/release-monitor/versions.env versions.env
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -112,5 +112,6 @@ jobs:
           commit-message: 'chore(deps): bump upstream dependencies'
           title: 'chore(deps): bump upstream dependencies'
           body-path: /tmp/pr-body.md
+          base: main
           branch: deps/bump-${{ github.run_number }}
           delete-branch: true

--- a/docs/contributor-ci-security.md
+++ b/docs/contributor-ci-security.md
@@ -61,6 +61,30 @@ The workflow does not sandbox arbitrary code that a maintainer has merged.
 Containing malicious code that passed review requires ephemeral or separately
 isolated GX10 runners.
 
+## Automated release monitor
+
+The release monitor treats upstream release metadata and requirements files as
+untrusted data. Processing that data happens in a read-only GitHub-hosted job
+with no repository secrets. The job uploads only a candidate `versions.env`.
+
+Pull request creation runs on a fresh GitHub-hosted runner. Before the release
+monitor PAT is available to any step, trusted code from the exact triggering
+`main` SHA checks that the candidate:
+
+- is a valid `versions.env`;
+- changes at least one monitored value;
+- changes only the release monitor's explicit key allowlist;
+- preserves every comment, line, and non-monitored value byte-for-byte.
+
+Only the validated `versions.env` is copied into the trusted checkout. The PR
+action is pinned by full commit SHA, commits only `versions.env`, and receives
+an explicit `main` base because the trusted checkout intentionally uses a
+detached exact SHA.
+
+This fresh-runner boundary is required even when the upstream parser validates
+its output. It prevents a parser defect or compromised upstream response from
+modifying a repository script and then reaching a later step that has the PAT.
+
 ## Maintainer runbook
 
 ### 1. Review the fork PR

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -62,6 +62,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERSIONS="${REPO_ROOT}/versions.env"
+VERSIONS_TARGET="${VERSIONS}"
+VERSIONS_CANDIDATE=""
 
 DO_UPDATE=0
 DO_BUMP_APT=0
@@ -76,6 +78,19 @@ done
 if [[ "${DO_UPDATE}" -eq 1 && "${DO_BUMP_APT}" -eq 1 ]]; then
   printf '%s\n' 'Choose either --update or --bump-apt-snapshot, not both.' >&2
   exit 1
+fi
+
+cleanup() {
+  if [[ -n "${VERSIONS_CANDIDATE}" ]]; then
+    rm -f "${VERSIONS_CANDIDATE}"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${DO_UPDATE}" -eq 1 ]]; then
+  VERSIONS_CANDIDATE="$(mktemp)"
+  cp "${VERSIONS_TARGET}" "${VERSIONS_CANDIDATE}"
+  VERSIONS="${VERSIONS_CANDIDATE}"
 fi
 
 log()  { printf '[check-updates] %s\n' "$*" >&2; }
@@ -108,7 +123,25 @@ update_env() {
     return 1
   fi
   tmp="$(mktemp)"
-  sed "s|^${key}=.*|${key}=${val}|" "${VERSIONS}" > "${tmp}"
+  python3 -c '
+import sys
+
+key, value = sys.argv[1:3]
+found = False
+for line in sys.stdin:
+    if line.startswith(f"{key}="):
+        print(f"{key}={value}")
+        found = True
+    else:
+        print(line, end="")
+if not found:
+    raise SystemExit(f"missing key {key}")
+' "${key}" "${val}" < "${VERSIONS}" > "${tmp}"
+  if ! python3 "${REPO_ROOT}/scripts/versions_env.py" "${tmp}" >/dev/null; then
+    rm -f "${tmp}"
+    log "Rejected unsafe ${key} candidate from upstream."
+    return 1
+  fi
   chmod 0644 "${tmp}"
   mv "${tmp}" "${VERSIONS}"
   ENV_UPDATES=$((ENV_UPDATES + 1))
@@ -185,14 +218,14 @@ vllm_pin() {
   printf '%s\n' "${VLLM_REQS_RAW}" \
     | python3 -c "
 import re, sys
-pkg = '''$pkg'''
+pkg = sys.argv[1]
 pat = re.compile(r'^\s*' + re.escape(pkg) + r'\s*==\s*([^\s#;]+)')
 for line in sys.stdin:
     m = pat.match(line)
     if m:
         print(m.group(1))
         break
-"
+" "${pkg}"
 }
 
 report() {
@@ -221,7 +254,10 @@ VLLM_LATEST=$(gh_latest_tag "vllm-project/vllm")
 # Use semver comparison so that a pinned pre-release (e.g. v0.23.1rc0) that is
 # newer than the latest stable (e.g. v0.23.0) is reported as INFO, not UPDATE.
 # Only flag UPDATE when the stable release is genuinely ahead of our pin.
-VLLM_CMP=$(python3 -c "
+VLLM_CMP=$(MONITOR_CURRENT_VLLM="${VLLM_REF}" \
+  MONITOR_LATEST_VLLM="${VLLM_LATEST}" \
+  python3 -c "
+import os
 import re
 
 def parse(value):
@@ -232,8 +268,8 @@ def parse(value):
     stage_rank = {'a': 0, 'b': 1, 'rc': 2, None: 3}[stage]
     return (int(major), int(minor), int(patch), stage_rank, int(number or 0))
 
-cur = parse('${VLLM_REF}')
-lat = parse('${VLLM_LATEST}')
+cur = parse(os.environ['MONITOR_CURRENT_VLLM'])
+lat = parse(os.environ['MONITOR_LATEST_VLLM'])
 print('ahead' if cur >= lat else 'behind')
 " 2>/dev/null || echo 'unknown')
 if [ "${VLLM_CMP}" = "behind" ]; then
@@ -395,11 +431,12 @@ APT_SNAPSHOT_STAMP=$(grep -m1 '^deb .*snapshot.ubuntu.com' "${APT_SOURCES}" \
 if [[ -z "${APT_SNAPSHOT_STAMP}" ]]; then
   printf 'WARN    %-30s could not parse snapshot date\n' "apt snapshot"
 else
-  APT_SNAPSHOT_AGE=$(python3 -c "
+  APT_SNAPSHOT_AGE=$(python3 -c '
+import sys
 from datetime import datetime, timezone
-snap = datetime.strptime('${APT_SNAPSHOT_STAMP}', '%Y%m%dT%H%M%SZ').replace(tzinfo=timezone.utc)
+snap = datetime.strptime(sys.argv[1], "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
 print((datetime.now(timezone.utc) - snap).days)
-")
+' "${APT_SNAPSHOT_STAMP}")
   APT_SNAPSHOT_DISPLAY="${APT_SNAPSHOT_STAMP:0:4}-${APT_SNAPSHOT_STAMP:4:2}-${APT_SNAPSHOT_STAMP:6:2}"
   TODAY_STAMP=$(date -u +"%Y%m%dT000000Z")
 
@@ -425,6 +462,17 @@ fi
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+
+if [[ "${DO_UPDATE}" -eq 1 ]]; then
+  if [[ "${ENV_UPDATES}" -gt 0 ]]; then
+    chmod 0644 "${VERSIONS_CANDIDATE}"
+    mv "${VERSIONS_CANDIDATE}" "${VERSIONS_TARGET}"
+  else
+    rm -f "${VERSIONS_CANDIDATE}"
+  fi
+  VERSIONS_CANDIDATE=""
+  VERSIONS="${VERSIONS_TARGET}"
+fi
 
 echo ""
 if [ "${UPDATES}" -eq 0 ]; then

--- a/scripts/validate-monitor-update.py
+++ b/scripts/validate-monitor-update.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate a release-monitor versions.env candidate against a trusted base."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from versions_env import VersionsEnvError, parse_versions_env
+
+
+ALLOWED_UPDATE_KEYS = {
+    "CUDA_BASE_DIGEST",
+    "FLASHINFER_REF",
+    "NCCL_REF",
+    "NUMBA_VERSION",
+    "TILELANG_VERSION",
+    "TORCHAUDIO_VERSION",
+    "TORCHVISION_VERSION",
+    "TORCH_VERSION",
+    "TVM_FFI_VERSION",
+    "UV_VERSION",
+    "VLLM_REF",
+}
+
+
+def render_expected_candidate(
+    base_text: str,
+    candidate_values: dict[str, str],
+    changed_keys: set[str],
+) -> str:
+    rendered = []
+    for raw_line in base_text.splitlines(keepends=True):
+        content = raw_line.rstrip("\r\n")
+        line_ending = raw_line[len(content):]
+        if "=" in content:
+            key = content.split("=", 1)[0]
+            if key in changed_keys:
+                raw_line = f"{key}={candidate_values[key]}{line_ending}"
+        rendered.append(raw_line)
+    return "".join(rendered)
+
+
+def validate_monitor_update(base_text: str, candidate_text: str) -> set[str]:
+    base_values = parse_versions_env(base_text)
+    candidate_values = parse_versions_env(candidate_text)
+    changed_keys = {
+        key for key in base_values if base_values[key] != candidate_values[key]
+    }
+    if not changed_keys:
+        raise VersionsEnvError("release monitor candidate has no changes")
+    unexpected = changed_keys - ALLOWED_UPDATE_KEYS
+    if unexpected:
+        raise VersionsEnvError(
+            "release monitor changed disallowed keys: "
+            + ", ".join(sorted(unexpected))
+        )
+    expected_text = render_expected_candidate(
+        base_text,
+        candidate_values,
+        changed_keys,
+    )
+    if candidate_text != expected_text:
+        raise VersionsEnvError(
+            "release monitor candidate contains changes outside approved values"
+        )
+    return changed_keys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base", type=Path)
+    parser.add_argument("candidate", type=Path)
+    args = parser.parse_args()
+    try:
+        changed_keys = validate_monitor_update(
+            args.base.read_text(encoding="utf-8"),
+            args.candidate.read_text(encoding="utf-8"),
+        )
+    except (OSError, UnicodeError, VersionsEnvError) as error:
+        parser.error(str(error))
+    print("Validated release monitor changes: " + ", ".join(sorted(changed_keys)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -363,6 +363,14 @@ if __name__ == "__main__":
         'exit "$result"' in workflow,
         "Workflow must fail instead of skipping when the duplicate check errors",
     )
+    check(
+        "group: monitor-upstream-releases" in workflow,
+        "Workflow must serialize monitor runs to prevent duplicate PR races",
+    )
+    check(
+        "cancel-in-progress: false" in workflow,
+        "Workflow must let the active monitor run finish before starting another",
+    )
 
     print(f"FAIL: {failed}")
     if failed:

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -22,7 +22,9 @@ if os.environ.get("FAKE_FAIL_ALL") == "1":
 if "raw.githubusercontent.com" in url:
     if os.environ.get("FAKE_FAIL_RAW") == "1":
         sys.exit(22)
-    if "/v0.26.0/" in url and os.environ.get("FAKE_CURRENT_REQUIREMENTS") != "1":
+    if os.environ.get("FAKE_REQUIREMENTS"):
+        print(os.environ["FAKE_REQUIREMENTS"])
+    elif "/v0.26.0/" in url and os.environ.get("FAKE_CURRENT_REQUIREMENTS") != "1":
         print("""torch==9.9.0
 torchvision==9.8.0
 torchaudio==9.7.0
@@ -41,9 +43,9 @@ flashinfer-python==0.6.14""")
 elif "vllm-project/vllm/releases/latest" in url:
     print(json.dumps({"tag_name": os.environ.get("FAKE_VLLM_TAG", "v0.26.0")}))
 elif "NVIDIA/nccl/releases/latest" in url:
-    print(json.dumps({"tag_name": "v2.30.7-1"}))
+    print(json.dumps({"tag_name": os.environ.get("FAKE_NCCL_TAG", "v2.30.7-1")}))
 elif "astral-sh/uv/releases/latest" in url:
-    print(json.dumps({"tag_name": "0.11.32"}))
+    print(json.dumps({"tag_name": os.environ.get("FAKE_UV_TAG", "0.11.32")}))
 elif "flashinfer-ai/flashinfer/releases/latest" in url:
     print(json.dumps({"tag_name": "v0.6.13"}))
 elif "/pypi/triton/json" in url:
@@ -68,6 +70,11 @@ def setup_case(directory):
     (root / "scripts").mkdir(parents=True)
     (root / "locks").mkdir()
     shutil.copy2(SOURCE_ROOT / "scripts" / "check-updates.sh", root / "scripts")
+    shutil.copy2(
+        SOURCE_ROOT / "scripts" / "validate-monitor-update.py",
+        root / "scripts",
+    )
+    shutil.copy2(SOURCE_ROOT / "scripts" / "versions_env.py", root / "scripts")
     shutil.copy2(SOURCE_ROOT / "versions.env", root / "versions.env")
     shutil.copy2(
         SOURCE_ROOT / "locks" / "apt-sources.list",
@@ -131,6 +138,31 @@ def test_dry_run_does_not_write_versions():
         assert (root / "versions.env").read_bytes() == before
 
 
+def test_valid_update_crosses_fresh_runner_policy():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        base = Path(directory) / "trusted-versions.env"
+        base.write_bytes((root / "versions.env").read_bytes())
+
+        result = run_check(root, env, "--update")
+        assert result.returncode == 0, result.stderr
+
+        validation = subprocess.run(
+            [
+                "python3",
+                str(root / "scripts" / "validate-monitor-update.py"),
+                str(base),
+                str(root / "versions.env"),
+            ],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert validation.returncode == 0, validation.stderr
+        assert "Validated release monitor changes" in validation.stdout
+
+
 def test_current_stack_reports_no_updates():
     with tempfile.TemporaryDirectory() as directory:
         root, env = setup_case(directory)
@@ -192,6 +224,58 @@ def test_invalid_vllm_release_tag_is_fatal():
         assert "Could not compare vLLM versions" in result.stderr
 
 
+def test_vllm_release_tag_cannot_inject_python():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        marker = Path(directory) / "python-injection-marker"
+        env["ATTACK_MARKER"] = str(marker)
+        env["FAKE_VLLM_TAG"] = (
+            "v0.26.1');__import__('pathlib').Path("
+            "__import__('os').environ['ATTACK_MARKER']).write_text('owned');#"
+        )
+        before = (root / "versions.env").read_bytes()
+
+        result = run_check(root, env, "--update")
+
+        assert result.returncode != 0
+        assert not marker.exists()
+        assert (root / "versions.env").read_bytes() == before
+
+
+def test_release_tag_cannot_inject_sed_commands():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        marker = Path(directory) / "sed-injection-marker"
+        env["FAKE_NCCL_TAG"] = f"v2.30.8-1|w {marker}"
+        before = (root / "versions.env").read_bytes()
+
+        result = run_check(root, env, "--update")
+
+        assert result.returncode != 0
+        assert "Rejected unsafe NCCL_REF candidate" in result.stderr
+        assert not marker.exists()
+        assert (root / "versions.env").read_bytes() == before
+
+
+def test_requirement_value_metacharacters_are_rejected():
+    with tempfile.TemporaryDirectory() as directory:
+        root, env = setup_case(directory)
+        env["FAKE_REQUIREMENTS"] = """torch==9.9.0
+torchvision==9.8.0
+torchaudio==9.7.0
+apache-tvm-ffi==9.6.0
+tilelang==9.5.0|e
+numba==9.4.0
+flashinfer-python==9.3.0"""
+        before = (root / "versions.env").read_bytes()
+
+        result = run_check(root, env, "--update")
+
+        assert result.returncode != 0
+        assert "Rejected unsafe TILELANG_VERSION candidate" in result.stderr
+        assert (root / "versions.env").read_bytes() == before
+
+
 def test_upstream_failure_is_fatal():
     with tempfile.TemporaryDirectory() as directory:
         root, env = setup_case(directory)
@@ -212,11 +296,15 @@ def main():
     tests = [
         test_target_vllm_requirements_are_applied,
         test_dry_run_does_not_write_versions,
+        test_valid_update_crosses_fresh_runner_policy,
         test_current_stack_reports_no_updates,
         test_newer_prerelease_remains_the_dependency_target,
         test_apt_snapshot_bump_only_updates_snapshot,
         test_requirement_fetch_failure_is_fatal,
         test_invalid_vllm_release_tag_is_fatal,
+        test_vllm_release_tag_cannot_inject_python,
+        test_release_tag_cannot_inject_sed_commands,
+        test_requirement_value_metacharacters_are_rejected,
         test_upstream_failure_is_fatal,
         test_mutating_modes_are_mutually_exclusive,
     ]

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -10,6 +10,7 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 ANY_ACTION = re.compile(r"^\s*uses:\s*([^#\s]+)@([^#\s]+)\s*$", re.MULTILINE)
 APPROVED_ACTIONS = {
     "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+    "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
     "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "docker/build-push-action": "53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
     "docker/login-action": "af1e73f918a031802d376d3c8bbc3fe56130a9b0",
@@ -100,6 +101,9 @@ def test_privileged_workflows_reject_untrusted_refs():
 def test_monitor_pr_creation_is_scoped_and_handles_detached_checkout():
     monitor = read(WORKFLOWS / "monitor-upstream-releases.yaml")
     workflow_header = monitor.split("\njobs:", 1)[0]
+    check_job = monitor.split("\n  check-deps:", 1)[1].split(
+        "\n  create-pr:", 1
+    )[0]
     create_pr_job = monitor.split("\n  create-pr:", 1)[1]
     create_pr_step = monitor.split("- name: Create Pull Request", 1)[1]
 
@@ -109,6 +113,17 @@ def test_monitor_pr_creation_is_scoped_and_handles_detached_checkout():
     assert "id-token: write" not in workflow_header
     assert "contents: write" in create_pr_job
     assert "pull-requests: write" in create_pr_job
+    assert "scripts/check-updates.sh --update" in check_job
+    assert "secrets." not in check_job
+    assert "actions/upload-artifact@" in check_job
+    assert "path: versions.env" in check_job
+    assert "scripts/check-updates.sh" not in create_pr_job
+    assert "actions/download-artifact@" in create_pr_job
+    assert (
+        create_pr_job.index("scripts/validate-monitor-update.py")
+        < create_pr_job.index("secrets.RELEASE_MONITOR_PAT")
+    )
+    assert "versions.env /tmp/release-monitor/versions.env" in create_pr_job
     assert "base: main" in create_pr_step
     assert "add-paths: versions.env" in create_pr_step
 
@@ -145,6 +160,7 @@ def test_sensitive_paths_have_codeowners():
         "/versions.env",
         "/locks/",
         "/scripts/",
+        "/tests/test-monitor-update-policy.py",
         "/tests/test-versions-contract.py",
     ):
         assert f"{path} @timothystewart6" in codeowners

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -97,6 +97,12 @@ def test_privileged_workflows_reject_untrusted_refs():
     assert "persist-credentials: false" in release
 
 
+def test_monitor_pr_creation_names_detached_checkout_base():
+    monitor = read(WORKFLOWS / "monitor-upstream-releases.yaml")
+    create_pr_step = monitor.split("- name: Create Pull Request", 1)[1]
+    assert "base: main" in create_pr_step
+
+
 def test_pr_workflows_are_read_only_and_secret_free():
     for path in WORKFLOWS.glob("*.yaml"):
         workflow = read(path)
@@ -153,6 +159,7 @@ def main():
         test_bump_workflow_preserves_approval_boundary,
         test_trusted_builds_checkout_the_exact_event_sha,
         test_privileged_workflows_reject_untrusted_refs,
+        test_monitor_pr_creation_names_detached_checkout_base,
         test_pr_workflows_are_read_only_and_secret_free,
         test_security_policy_runs_for_every_pull_request,
         test_sensitive_paths_have_codeowners,

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -97,10 +97,20 @@ def test_privileged_workflows_reject_untrusted_refs():
     assert "persist-credentials: false" in release
 
 
-def test_monitor_pr_creation_names_detached_checkout_base():
+def test_monitor_pr_creation_is_scoped_and_handles_detached_checkout():
     monitor = read(WORKFLOWS / "monitor-upstream-releases.yaml")
+    workflow_header = monitor.split("\njobs:", 1)[0]
+    create_pr_job = monitor.split("\n  create-pr:", 1)[1]
     create_pr_step = monitor.split("- name: Create Pull Request", 1)[1]
+
+    assert "contents: read" in workflow_header
+    assert "contents: write" not in workflow_header
+    assert "pull-requests: write" not in workflow_header
+    assert "id-token: write" not in workflow_header
+    assert "contents: write" in create_pr_job
+    assert "pull-requests: write" in create_pr_job
     assert "base: main" in create_pr_step
+    assert "add-paths: versions.env" in create_pr_step
 
 
 def test_pr_workflows_are_read_only_and_secret_free():
@@ -159,7 +169,7 @@ def main():
         test_bump_workflow_preserves_approval_boundary,
         test_trusted_builds_checkout_the_exact_event_sha,
         test_privileged_workflows_reject_untrusted_refs,
-        test_monitor_pr_creation_names_detached_checkout_base,
+        test_monitor_pr_creation_is_scoped_and_handles_detached_checkout,
         test_pr_workflows_are_read_only_and_secret_free,
         test_security_policy_runs_for_every_pull_request,
         test_sensitive_paths_have_codeowners,

--- a/tests/test-monitor-update-policy.py
+++ b/tests/test-monitor-update-policy.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Security tests for the release monitor artifact boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+MODULE_PATH = ROOT / "scripts" / "validate-monitor-update.py"
+SPEC = importlib.util.spec_from_file_location("validate_monitor_update", MODULE_PATH)
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(VALIDATOR)
+
+BASE_TEXT = (ROOT / "versions.env").read_text(encoding="utf-8")
+BASE_VALUES = VALIDATOR.parse_versions_env(BASE_TEXT)
+
+VALID_REPLACEMENTS = {
+    "CUDA_BASE_DIGEST": "sha256:" + "1" * 64,
+    "FLASHINFER_REF": "v9.8.7",
+    "NCCL_REF": "v9.8.7-1",
+    "NUMBA_VERSION": "9.8.7",
+    "TILELANG_VERSION": "9.8.7",
+    "TORCHAUDIO_VERSION": "9.8.7",
+    "TORCHVISION_VERSION": "9.8.7",
+    "TORCH_VERSION": "9.8.7",
+    "TVM_FFI_VERSION": "9.8.7",
+    "UV_VERSION": "9.8.7",
+    "VLLM_REF": "v9.8.7",
+}
+
+
+def replace_value(text, key, value):
+    old = f"{key}={BASE_VALUES[key]}"
+    assert old in text
+    return text.replace(old, f"{key}={value}", 1)
+
+
+def assert_rejected(candidate, reason):
+    try:
+        VALIDATOR.validate_monitor_update(BASE_TEXT, candidate)
+    except VALIDATOR.VersionsEnvError:
+        return
+    raise AssertionError(f"accepted unsafe monitor candidate: {reason}")
+
+
+def test_every_monitor_key_is_individually_allowed():
+    assert set(VALID_REPLACEMENTS) == VALIDATOR.ALLOWED_UPDATE_KEYS
+    for key, value in VALID_REPLACEMENTS.items():
+        candidate = replace_value(BASE_TEXT, key, value)
+        assert VALIDATOR.validate_monitor_update(BASE_TEXT, candidate) == {key}
+
+
+def test_multiple_approved_values_are_allowed_together():
+    candidate = BASE_TEXT
+    expected = {"VLLM_REF", "TORCH_VERSION", "UV_VERSION"}
+    for key in expected:
+        candidate = replace_value(candidate, key, VALID_REPLACEMENTS[key])
+    assert VALIDATOR.validate_monitor_update(BASE_TEXT, candidate) == expected
+
+
+def test_policy_covers_every_scripted_monitor_update():
+    script = (ROOT / "scripts" / "check-updates.sh").read_text(encoding="utf-8")
+    report_keys = set(
+        re.findall(
+            r'^\s*report\s+"[^"]+"\s+"([A-Z0-9_]+)"',
+            script,
+            re.MULTILINE,
+        )
+    )
+    explicit_keys = set(re.findall(r'update_env\s+"([A-Z0-9_]+)"', script))
+    assert report_keys | explicit_keys == VALIDATOR.ALLOWED_UPDATE_KEYS
+
+
+def test_every_other_schema_key_is_rejected():
+    disallowed = set(BASE_VALUES) - VALIDATOR.ALLOWED_UPDATE_KEYS
+    assert disallowed
+    for key in disallowed:
+        if key.endswith("_COMMIT"):
+            replacement = "1" * 40
+        elif key == "GB10_BUILD":
+            replacement = str(int(BASE_VALUES[key]) + 1)
+        elif key == "CUDA_BASE_IMAGE":
+            replacement = "nvidia/cuda:99.9.9-devel-ubuntu24.04"
+        elif key.endswith("_VERSION"):
+            replacement = "99.9.9"
+        else:
+            replacement = BASE_VALUES[key] + "x"
+        candidate = replace_value(BASE_TEXT, key, replacement)
+        assert_rejected(candidate, key)
+
+
+def test_comment_addition_is_rejected():
+    candidate = replace_value(BASE_TEXT, "UV_VERSION", "9.8.7")
+    assert_rejected(candidate + "# injected comment\n", "comment addition")
+
+
+def test_comment_edit_is_rejected():
+    candidate = replace_value(BASE_TEXT, "UV_VERSION", "9.8.7")
+    candidate = candidate.replace(
+        "# versions.env - the authoritative source of truth for all build inputs.",
+        "# modified by upstream",
+    )
+    assert_rejected(candidate, "comment edit")
+
+
+def test_reordering_is_rejected():
+    lines = replace_value(BASE_TEXT, "UV_VERSION", "9.8.7").splitlines(True)
+    lines[0], lines[1] = lines[1], lines[0]
+    assert_rejected("".join(lines), "line reordering")
+
+
+def test_no_change_is_rejected():
+    assert_rejected(BASE_TEXT, "no change")
+
+
+def test_missing_key_is_rejected():
+    candidate = replace_value(BASE_TEXT, "UV_VERSION", "9.8.7")
+    candidate = candidate.replace(
+        f"NCCL_COMMIT={BASE_VALUES['NCCL_COMMIT']}\n",
+        "",
+    )
+    assert_rejected(candidate, "missing key")
+
+
+def test_duplicate_key_is_rejected():
+    candidate = replace_value(BASE_TEXT, "UV_VERSION", "9.8.7")
+    candidate += "UV_VERSION=9.8.7\n"
+    assert_rejected(candidate, "duplicate key")
+
+
+def test_shell_and_python_payloads_are_rejected():
+    payloads = (
+        "$(touch /tmp/owned)",
+        "9.8.7|e",
+        "9.8.7';__import__('os').system('id')#",
+        "9.8.7\nEVIL=value",
+        "https://attacker.invalid/package.whl",
+    )
+    for payload in payloads:
+        candidate = replace_value(BASE_TEXT, "UV_VERSION", payload)
+        assert_rejected(candidate, payload)
+
+
+def main():
+    tests = [
+        test_every_monitor_key_is_individually_allowed,
+        test_multiple_approved_values_are_allowed_together,
+        test_policy_covers_every_scripted_monitor_update,
+        test_every_other_schema_key_is_rejected,
+        test_comment_addition_is_rejected,
+        test_comment_edit_is_rejected,
+        test_reordering_is_rejected,
+        test_no_change_is_rejected,
+        test_missing_key_is_rejected,
+        test_duplicate_key_is_rejected,
+        test_shell_and_python_payloads_are_rejected,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} monitor update policy tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- set `main` explicitly as the dependency pull request base
- preserve the exact-SHA detached checkout that caused the original action error
- process upstream metadata in a read-only, secret-free job
- transfer only a candidate `versions.env` to a fresh PR-creation runner
- validate the candidate against trusted `main` before any PAT-backed step
- restrict automated commits to `versions.env` and serialize monitor runs
- add adversarial, policy-exhaustiveness, workflow-boundary, and happy-path tests

## Failures addressed

The release monitor previously reached PR-body generation but failed because
`peter-evans/create-pull-request` could not infer a base branch from the
intentional detached checkout:

```text
When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.
```

The pinned action source confirms that `base: main` is required for this exact
checkout state and is then used to construct the PR branch.

## Security boundary

Upstream release tags, package metadata, image metadata, and vLLM requirements
are untrusted data. They are now processed only in a read-only GitHub-hosted job
with no repository secrets. That job uploads only `versions.env`.

PR creation uses a fresh GitHub-hosted runner checked out at the exact trusted
workflow SHA. Trusted code validates the downloaded candidate before the first
step that receives `RELEASE_MONITOR_PAT`. Validation requires:

- the complete strict `versions.env` schema
- at least one changed monitored value
- changes only to the explicit release-monitor key allowlist
- byte-for-byte preservation of comments, ordering, and every other value

The parser no longer interpolates upstream values into Python or sed program
text. Values are passed as data, each update is schema-validated, and the
complete update is transactional. Any failure leaves the original file
unchanged.

The PR action remains pinned by full commit SHA, receives `base: main`, and can
commit only `versions.env`. Workflow concurrency prevents duplicate-PR races.
The discovery job is read-only and the unused OIDC permission remains removed.

## Test coverage

- valid end-to-end candidate generation and fresh-runner validation
- Python source-injection payload in a release tag
- sed metacharacter and file-write payload in a release tag
- unsafe vLLM requirement value
- every monitored key individually and multiple valid changes together
- every non-monitored schema key
- comments, ordering, missing keys, duplicate keys, and no-change artifacts
- shell, Python, newline, URL, and metacharacter payloads
- automatic enforcement that the validator allowlist matches every scripted update
- workflow ordering that validates before PAT use
- pinned actions, exact-SHA checkouts, permissions, commit scope, and concurrency

## Validation

- every `tests/test-*.py` suite
- `actionlint .github/workflows/*.yaml`
- `bash -n scripts/*.sh tests/*.sh`
- `shellcheck -S warning scripts/*.sh tests/*.sh`
- `python3 -m py_compile scripts/*.py tests/*.py`
- `git diff --check`

Failed run: https://github.com/timothystewart6/vllm-gb10/actions/runs/30397203109/job/90403065750
