### PR TITLE
fix(monitor): enforce generated update lifecycle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 /.github/dependabot.yml @timothystewart6
 /.github/workflows/ @timothystewart6
 /AGENTS.md @timothystewart6
+/CLAUDE.md @timothystewart6
 /CONTRIBUTING.md @timothystewart6
 /Dockerfile @timothystewart6
 /docs/contributor-ci-security.md @timothystewart6

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Security-sensitive build and automation paths.
 /.github/PULL_REQUEST_TEMPLATE.md @timothystewart6
+/.github/ISSUE_TEMPLATE/ @timothystewart6
 /.github/CODEOWNERS @timothystewart6
 /.github/dependabot.yml @timothystewart6
 /.github/workflows/ @timothystewart6
@@ -7,6 +8,7 @@
 /CONTRIBUTING.md @timothystewart6
 /Dockerfile @timothystewart6
 /docs/contributor-ci-security.md @timothystewart6
+/docs/repository-guide.md @timothystewart6
 /versions.env @timothystewart6
 /locks/ @timothystewart6
 /scripts/ @timothystewart6

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,7 @@
 /locks/ @timothystewart6
 /scripts/ @timothystewart6
 /tests/test-ci-security-policy.py @timothystewart6
+/tests/test-monitor-lifecycle.py @timothystewart6
 /tests/test-monitor-update-policy.py @timothystewart6
+/tests/test-update-versions-env.py @timothystewart6
 /tests/test-versions-contract.py @timothystewart6

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Security-sensitive build and automation paths.
 /.github/PULL_REQUEST_TEMPLATE.md @timothystewart6
 /.github/ISSUE_TEMPLATE/ @timothystewart6
+/.github/copilot-instructions.md @timothystewart6
 /.github/CODEOWNERS @timothystewart6
 /.github/dependabot.yml @timothystewart6
 /.github/workflows/ @timothystewart6

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,10 @@ body:
         [vllm-project/vllm](https://github.com/vllm-project/vllm/issues) instead.
         Open here only if the issue is specific to this image or the GB10 build.
 
+        Search open and closed issues and pull requests before filing. Include
+        the exact release, commit, or Actions run and enough evidence to
+        distinguish repository behavior from an upstream failure.
+
   - type: input
     id: image-tag
     attributes:
@@ -48,6 +52,21 @@ body:
       required: true
 
   - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected and actual behavior
+      description: State the invariant that failed, what should have happened, and what happened instead.
+    validations:
+      required: true
+
+  - type: input
+    id: related-work
+    attributes:
+      label: Related issues, pull requests, or Actions run
+      description: Link related open or closed work and the failing workflow run when applicable.
+      placeholder: "https://github.com/timothystewart6/vllm-gb10/actions/runs/..."
+
+  - type: textarea
     id: logs
     attributes:
       label: Relevant logs or error output
@@ -58,3 +77,13 @@ body:
     attributes:
       label: DGX Spark firmware version
       placeholder: "e.g. 1.2.3"
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched open and closed issues and pull requests.
+          required: true
+        - label: I confirmed this is specific to this image, GB10 build, or repository automation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/version_bump.yml
+++ b/.github/ISSUE_TEMPLATE/version_bump.yml
@@ -2,6 +2,13 @@ name: Version bump request
 description: Request a newer version of vLLM, PyTorch, NCCL, FlashInfer, or another component
 labels: ["bump"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Search open and closed issues, pull requests, and recent monitor runs
+        before filing. Link the upstream release and note compatibility or
+        migration concerns that could affect generation, build, or runtime.
+
   - type: dropdown
     id: component
     attributes:
@@ -39,9 +46,27 @@ body:
     attributes:
       label: Upstream release link
       placeholder: "https://github.com/vllm-project/vllm/releases/tag/v0.21.0"
+    validations:
+      required: true
+
+  - type: input
+    id: related-work
+    attributes:
+      label: Related issue, pull request, or monitor run
+      description: Link existing work so this request does not duplicate it.
 
   - type: textarea
     id: notes
     attributes:
       label: Notes
       description: Anything relevant - breaking changes, GB10-specific concerns, etc.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched open and closed issues and pull requests.
+          required: true
+        - label: I checked recent Monitor Upstream Releases runs.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,35 @@
 
 <!-- One or two sentences. -->
 
+## Reasoning and evidence
+
+<!-- State the failed invariant, reproduction, root cause or bounded
+     hypothesis, and related issues, PRs, or Actions runs. -->
+
+## Lifecycle impact
+
+<!-- List the inputs, detection, validation, generation, build, verification,
+     metadata, and release stages inspected. Write "None" only after checking
+     the repository guide. -->
+
+## Security impact
+
+<!-- Describe trust-boundary, token, runner, untrusted-input, and generated-file
+     effects. State why the existing boundary remains safe. -->
+
+## Validation
+
+<!-- List exact commands and results. Include the original failing case,
+     regression coverage, generated repository state, and anything that needs
+     DGX Spark or post-merge validation. -->
+
 ## Checklist
 
+- [ ] Read the repository guide and relevant contributor and security documentation
+- [ ] Searched open and closed issues and PRs and linked related work
+- [ ] Inspected callers, consumers, generated outputs, and downstream workflow stages
+- [ ] Added a regression that fails for the original reason and passes with this fix
+- [ ] Reviewed the complete diff and changed-file list
 - [ ] This change is specific to the GB10 build or CI - not a patch to upstream vLLM, NCCL, FlashInfer, or PyTorch behavior
 - [ ] `versions.env` changes follow the [input integration checklist](../CONTRIBUTING.md#adding-or-changing-a-versionsenv-input)
 - [ ] A maintainer reviewed the exact SHA before manually dispatching trusted `run-bump.yaml`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+[AGENTS.md](../AGENTS.md) is the canonical repository instruction source.
+Read and follow it before working in this repository. Keep shared instructions
+there instead of duplicating them in this Copilot compatibility file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # Repository Agent Instructions
 
-`AGENTS.md` is the canonical repository instruction source. `CLAUDE.md` is a
-compatibility shim that imports this file. Keep shared instructions here and
-do not duplicate them in tool-specific files.
+`AGENTS.md` is the canonical repository instruction source. Codex and supported
+GitHub Copilot agent and review surfaces read it directly. `CLAUDE.md` imports
+it, and `.github/copilot-instructions.md` points Copilot surfaces here. Keep
+shared instructions in this file and do not duplicate them in tool-specific
+files.
 
 ## Required repository onboarding
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,39 @@
 # Repository Agent Instructions
 
+## Required repository onboarding
+
+Before opening an issue, editing code, or opening a pull request:
+
+1. Read [Repository guide and change reasoning](docs/repository-guide.md),
+   `README.md`, and the relevant section of `CONTRIBUTING.md`.
+2. Read [Contributor CI security workflow](docs/contributor-ci-security.md)
+   before changing workflows, scripts, `Dockerfile`, build inputs, locks,
+   checksums, or release automation.
+3. Inspect the working tree, the relevant implementation, its callers and
+   consumers, nearby tests, and recent history. Do not reason from one failing
+   line or workflow step in isolation.
+4. Search open and closed issues and pull requests, plus relevant Actions runs
+   when available. Link related work instead of creating an undocumented
+   duplicate.
+5. Classify the problem as repository build logic, automation, generated data,
+   runner or environment behavior, or upstream component behavior. Confirm
+   that it is in this repository's scope.
+6. Record the invariant, evidence, root cause or bounded hypothesis, affected
+   lifecycle stages, security impact, and validation plan before proposing a
+   change.
+
+Do not open an issue that lacks an exact affected version or commit, expected
+and actual behavior, reproduction evidence, and related logs or workflow URLs
+when they exist. Do not open a pull request until the failure is reproduced by
+a test or a documented manual check. A regression test must fail for the
+original reason and pass after the fix.
+
+Before finalizing a pull request, inspect the complete diff and changed-file
+list, run every applicable validation command, test the state produced by
+automation when generated files are involved, and update documentation and
+templates when the process or invariant changed. State any hardware-only or
+post-merge validation that could not run in the pull request.
+
 Before adding, removing, or changing a `versions.env` variable, read and follow
 [Adding or changing a versions.env input](CONTRIBUTING.md#adding-or-changing-a-versionsenv-input).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Repository Agent Instructions
 
+`AGENTS.md` is the canonical repository instruction source. `CLAUDE.md` is a
+compatibility shim that imports this file. Keep shared instructions here and
+do not duplicate them in tool-specific files.
+
 ## Required repository onboarding
 
 Before opening an issue, editing code, or opening a pull request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 Before adding, removing, or changing a `versions.env` variable, read and follow
 [Adding or changing a versions.env input](CONTRIBUTING.md#adding-or-changing-a-versionsenv-input).
 
+Before changing release-monitor detection, fixtures, or PR creation, read and
+follow [Automated release monitor lifecycle](CONTRIBUTING.md#automated-release-monitor-lifecycle).
+Validation must apply a representative generated update and run the hosted
+suite against that resulting repository state. Passing tests only against the
+pre-update branch is not sufficient.
+
 Do not treat a passing schema validation as complete integration. The variable
 must participate in build revision accounting, build arguments, its consuming
 script or lock seed, release metadata, documentation, and contract tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+@AGENTS.md
+
+<!--
+AGENTS.md is the canonical source. Keep this file as an import shim instead of
+copying shared instructions here.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,53 @@ You do not need to SSH into the Spark or run anything locally.
 
 **Do not edit lockfiles by hand.** They are generated outputs.
 
+## Automated release monitor lifecycle
+
+`Monitor Upstream Releases` is complete only when the generated dependency PR
+passes the same hosted checks required for merge. A green monitor workflow run
+proves that detection, validation, artifact transfer, and PR creation worked.
+It does not prove that the repository remains valid after the candidate values
+are applied.
+
+The full lifecycle is:
+
+1. Run the monitor from `main`. Upstream data is processed in the read-only,
+   secret-free job.
+2. A fresh hosted runner validates the candidate `versions.env` against the
+   exact trusted `main` SHA, then creates a PR containing only that file.
+3. Run every hosted test against the generated PR state. This is the first
+   validation of the repository after the candidate has been applied.
+4. Review the generated PR's exact 40-character head SHA.
+5. Dispatch `run-bump.yaml` from `main` with the dependency branch and reviewed
+   SHA. Trusted `main` code resolves commits, increments or resets
+   `GB10_BUILD`, regenerates locks, validates output paths, and pushes the
+   generated commit back to the branch.
+6. Run hosted tests again and review the resolved SHAs, build number, and
+   lockfile changes.
+7. Merge the dependency PR. The `versions.env` or lockfile change triggers the
+   trusted `main` image build, verification, and release jobs.
+
+Tests for monitor detection must use an explicit deterministic baseline for
+every monitored key. They must not inherit mutable production values while
+also asserting fixed mock outputs or update counts. The baseline key set must
+equal the production monitor allowlist so a newly watched key fails closed
+until its fixture and downstream expectations are added.
+
+For a monitor or bump change, test both sides of the transition:
+
+- run the behavior against the current trusted input;
+- apply each allowed generated value change;
+- validate the resulting complete `versions.env`;
+- verify duplicate detection, PR-body labels, build-number behavior, build
+  arguments, release metadata, and workflow handoff order;
+- run the complete hosted suite against at least one representative generated
+  repository state.
+
+If a generated dependency PR exposes an automation-test defect, fix the test
+or trusted automation in a separate PR. Close the generated dependency PR,
+merge the automation fix, and rerun the monitor from the new `main`. Do not add
+unrelated executable changes to the generated dependency PR.
+
 ### Adding or changing a versions.env input
 
 `versions.env` is an integration contract, not only a list of values. Adding,
@@ -55,9 +102,10 @@ Complete this checklist in the same change:
 5. Add a human-readable label in `scripts/versions_diff.py` and include numeric
    version inputs in `scripts/render-metadata.sh`. Update release-note output
    when the component belongs in the published component table.
-6. Update test fixtures and add behavior coverage for the consumer. Do not add
-   a one-off test that only checks for a string when the behavior can be
-   derived from the schema.
+6. Update test fixtures and add behavior coverage for the consumer. If the key
+   is monitored, add it to the deterministic monitor fixture and generated-PR
+   lifecycle coverage. Do not add a one-off test that only checks for a string
+   when the behavior can be derived from the schema.
 7. Run every hosted test with `for test_file in tests/test-*.py; do python3
    "$test_file"; done`, plus shell syntax, ShellCheck, actionlint, and
    `git diff --check`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ This repo builds and ships a reproducible vLLM Docker image for the NVIDIA DGX
 Spark (GB10 / sm_121a). Contributions are welcome, but the scope is intentionally
 narrow: keep the build working, keep the pins current, keep it reproducible.
 
+Start with [Repository guide and change reasoning](docs/repository-guide.md).
+It maps inputs, trusted automation, generated outputs, tests, publishing, and
+the evidence required before opening an issue or pull request.
+
 ## How builds work
 
 All version inputs live in [`versions.env`](versions.env). Every field that can
@@ -172,6 +176,13 @@ If the issue is upstream, please file it there directly:
 ## Opening a PR
 
 - Target `main`.
+- Search open and closed issues and pull requests before starting.
+- Explain the invariant that failed, the root cause or bounded hypothesis, and
+  every upstream and downstream stage inspected.
+- Include a regression that fails for the original reason and passes with the
+  fix. For generated changes, test the resulting repository state.
+- Complete the reasoning, lifecycle, security, and validation sections in the
+  pull request template.
 - Include the output of the smoke test (`tests/smoke-test.sh`) if you changed
   anything in the Dockerfile or build scripts.
 - Keep commits focused - one logical change per PR.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ CI also triggers on changes to `Dockerfile`, `locks/`, `scripts/`, and
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Security issues: [SECURITY.md](SECURITY.md).
+Start with the [repository guide](docs/repository-guide.md), then follow
+[CONTRIBUTING.md](CONTRIBUTING.md). Security issues:
+[SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/docs/contributor-ci-security.md
+++ b/docs/contributor-ci-security.md
@@ -85,6 +85,11 @@ This fresh-runner boundary is required even when the upstream parser validates
 its output. It prevents a parser defect or compromised upstream response from
 modifying a repository script and then reaching a later step that has the PAT.
 
+PR creation is not the final monitor acceptance gate. The generated PR must
+pass hosted CI with the candidate already applied, then pass the trusted bump
+handoff before merge. See
+[Automated release monitor lifecycle](../CONTRIBUTING.md#automated-release-monitor-lifecycle).
+
 ## Maintainer runbook
 
 ### 1. Review the fork PR

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,118 @@
+# Repository guide and change reasoning
+
+This repository produces a reproducible vLLM image for one platform: NVIDIA
+DGX Spark with GB10. Its automation is a pipeline, so a change is not complete
+when one script or workflow step works. Review the input, every transformation,
+the generated repository state, and each downstream consumer.
+
+## Repository map
+
+| Layer | Source of truth | Purpose |
+|---|---|---|
+| User and release behavior | `README.md` | Supported platform, image use, tags, and release expectations |
+| Pinned inputs | `versions.env` | Complete declarative build input set |
+| Input policy | `scripts/versions_env.py` | Schema, value validation, and build-revision roles |
+| Upstream detection | `scripts/check-updates.sh` | Finds candidate release changes without publishing them |
+| Monitor boundary | `scripts/validate-monitor-update.py` and `.github/workflows/monitor-upstream-releases.yaml` | Restricts generated PRs to approved declarative changes |
+| Trusted generation | `.github/workflows/run-bump.yaml` and `scripts/bump.sh` | Resolves reviewed refs and regenerates locks on DGX Spark |
+| Image definition | `Dockerfile`, `scripts/build-args.sh`, `locks/`, and `checksums/` | Converts validated inputs into reproducible build layers |
+| Build and verification | `.github/workflows/build-image.yaml` and `.github/workflows/verify-reproducible.yaml` | Builds trusted `main`, runs smoke checks, and verifies output |
+| Release output | `.github/workflows/create-release.yaml`, `scripts/render-metadata.sh`, and `scripts/generate-release-notes.sh` | Publishes tags, metadata, and release notes |
+| Contracts | `tests/test-*.py` | Derives cross-layer completeness and security requirements |
+| Trust model | `docs/contributor-ci-security.md` | Separates untrusted PR data from persistent runners and credentials |
+
+## Reason from invariants
+
+Start by writing the invariant that failed. Examples include:
+
+- one `versions.env` input produces one validated and reproducible image;
+- a monitored value change reaches build accounting, generation, build
+  arguments, metadata, and release output;
+- untrusted pull request code never runs on a persistent runner;
+- reviewed declarative data is applied only to the exact approved commit;
+- generated output changes only its documented allowlist;
+- a green detection job is not accepted until the generated repository state
+  passes hosted tests.
+
+Then trace the value or control decision in both directions. Find where it
+originates, how it is validated and transformed, which files it generates,
+which later jobs consume it, and what evidence proves the final behavior.
+Search by semantic role and variable name, not only by the failing message.
+
+## Before opening an issue
+
+1. Reproduce against the latest applicable image, commit, or workflow run.
+2. Search open and closed issues and pull requests for the error, component,
+   variable, workflow, and affected release.
+3. Decide whether the failure belongs to this image, repository automation,
+   DGX Spark environment, or an upstream project.
+4. Capture expected behavior, actual behavior, minimal reproduction, exact
+   version or commit, sanitized logs, and workflow URL.
+5. Link related work and explain what is different about the new report.
+6. Use a private security advisory instead of a public issue for a suspected
+   vulnerability.
+
+An unexplained failed command is evidence, not yet a root cause. If the cause
+is not proven, state a bounded hypothesis and what evidence would confirm or
+reject it.
+
+## Before opening a pull request
+
+1. Read the issue history, related pull requests, relevant documentation,
+   implementation, callers, consumers, tests, and recent commits.
+2. Reproduce the original failure with a focused test or documented manual
+   procedure before changing behavior.
+3. Identify every affected lifecycle stage using the repository map.
+4. Preserve the trusted-runner boundary. Treat upstream responses, contributor
+   branches, generated diffs, refs, digests, package metadata, and filenames as
+   untrusted data until validated.
+5. Prefer derived or table-driven contracts over copied lists and fixed counts.
+   A new schema key or monitored key should fail closed until all required
+   consumers are present.
+6. Test normal, boundary, malformed, duplicate, missing, stale, and adversarial
+   inputs that are plausible at each trust boundary.
+7. For automation, test the state before the transition and the repository
+   state produced after it. Continue through the next workflow handoff.
+8. Inspect the complete diff and changed-file list. Confirm that unrelated
+   files, secrets, temporary output, and ignored files are absent.
+9. Run every applicable local check and record exact results. Identify DGX
+   Spark, credentialed, hardware, or post-merge checks that remain.
+10. Update documentation when an invariant, lifecycle, operator action, or
+    security assumption changed.
+
+## Validation baseline
+
+The GitHub-hosted test workflow discovers every `tests/test-*.py` file. Run the
+same suites locally, then run the repository's shell and workflow checks:
+
+```bash
+for test_file in tests/test-*.py; do python3 "${test_file}"; done
+actionlint .github/workflows/*.yaml
+bash -n scripts/*.sh tests/*.sh
+shellcheck -S warning scripts/*.sh tests/*.sh
+python3 -m py_compile scripts/*.py tests/*.py
+git diff --check
+```
+
+Dockerfile and build-script changes also require the DGX Spark smoke test.
+Never weaken or bypass a check because it cannot run locally. Record the
+remaining trusted or hardware-dependent validation and follow the documented
+workflow.
+
+## Review standard
+
+A review is complete only when it can answer:
+
+- What invariant failed, and what evidence proves the root cause?
+- Why is the change in this repository rather than upstream?
+- Which callers, consumers, generated outputs, and later workflows were
+  inspected?
+- Which test fails on the original behavior and passes after the change?
+- What malformed, stale, duplicate, or adversarial cases were considered?
+- Does any untrusted value reach code execution, credentials, persistent
+  storage, a privileged runner, a git ref, or a published artifact?
+- What happens immediately after merge, and what proves that stage is
+  compatible?
+
+If any answer is unknown, document the gap instead of presenting the change as
+fully verified.

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -5,6 +5,14 @@ DGX Spark with GB10. Its automation is a pipeline, so a change is not complete
 when one script or workflow step works. Review the input, every transformation,
 the generated repository state, and each downstream consumer.
 
+## Agent instruction source
+
+`AGENTS.md` is the single source of shared repository instructions.
+`CLAUDE.md` imports it for Claude Code compatibility and must not repeat its
+content. Put instructions that apply to every coding agent in `AGENTS.md`.
+Add tool-specific text only when another agent cannot follow the shared rule,
+and keep that exception in the importing compatibility file.
+
 ## Repository map
 
 | Layer | Source of truth | Purpose |

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -9,9 +9,13 @@ the generated repository state, and each downstream consumer.
 
 `AGENTS.md` is the single source of shared repository instructions.
 `CLAUDE.md` imports it for Claude Code compatibility and must not repeat its
-content. Put instructions that apply to every coding agent in `AGENTS.md`.
-Add tool-specific text only when another agent cannot follow the shared rule,
-and keep that exception in the importing compatibility file.
+content. Codex reads `AGENTS.md` directly. GitHub Copilot coding agent and
+supported review and chat surfaces also read it directly, while
+`.github/copilot-instructions.md` provides a minimal pointer for Copilot
+surfaces that require that filename. Put instructions that apply to every
+coding agent in `AGENTS.md`. Add tool-specific text only when another agent
+cannot follow the shared rule, and keep that exception in its compatibility
+file.
 
 ## Repository map
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -212,22 +212,13 @@ fi
 # ---------------------------------------------------------------------------
 # 6. Write resolved values back to versions.env
 # ---------------------------------------------------------------------------
-_update_env() {
-  local key="$1" val="$2"
-  if grep -q "^${key}=" "${VERSIONS}"; then
-    # Use | as sed delimiter to safely handle values that contain /
-    sed -i "s|^${key}=.*|${key}=${val}|" "${VERSIONS}"
-  else
-    printf '\n%s=%s\n' "${key}" "${val}" >> "${VERSIONS}"
-  fi
-}
-
-_update_env CUDA_BASE_DIGEST  "${CUDA_BASE_DIGEST}"
-_update_env GB10_BUILD        "${GB10_BUILD}"
-_update_env NCCL_COMMIT       "${NCCL_COMMIT}"
-_update_env VLLM_COMMIT       "${VLLM_COMMIT}"
-_update_env FLASHINFER_COMMIT "${FLASHINFER_COMMIT}"
-_update_env RAY_VERSION       "${RAY_VERSION}"
+python3 "${REPO_ROOT}/scripts/update-versions-env.py" "${VERSIONS}" \
+  "CUDA_BASE_DIGEST=${CUDA_BASE_DIGEST}" \
+  "GB10_BUILD=${GB10_BUILD}" \
+  "NCCL_COMMIT=${NCCL_COMMIT}" \
+  "VLLM_COMMIT=${VLLM_COMMIT}" \
+  "FLASHINFER_COMMIT=${FLASHINFER_COMMIT}" \
+  "RAY_VERSION=${RAY_VERSION}"
 
 log "versions.env updated with resolved SHAs and digest."
 

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -112,38 +112,20 @@ UPDATES=0
 ENV_UPDATES=0
 
 # ---------------------------------------------------------------------------
-# sed -i is not portable between macOS and Linux. Use a temp-file swap.
+# Pass upstream values as data to the shared atomic schema-validating writer.
 # ---------------------------------------------------------------------------
 update_env() {
   local key="$1"
   local val="$2"
-  local tmp
   if ! grep -q "^${key}=" "${VERSIONS}"; then
     log "Cannot update missing key ${key} in versions.env."
     return 1
   fi
-  tmp="$(mktemp)"
-  python3 -c '
-import sys
-
-key, value = sys.argv[1:3]
-found = False
-for line in sys.stdin:
-    if line.startswith(f"{key}="):
-        print(f"{key}={value}")
-        found = True
-    else:
-        print(line, end="")
-if not found:
-    raise SystemExit(f"missing key {key}")
-' "${key}" "${val}" < "${VERSIONS}" > "${tmp}"
-  if ! python3 "${REPO_ROOT}/scripts/versions_env.py" "${tmp}" >/dev/null; then
-    rm -f "${tmp}"
+  if ! python3 "${REPO_ROOT}/scripts/update-versions-env.py" \
+      "${VERSIONS}" "${key}=${val}"; then
     log "Rejected unsafe ${key} candidate from upstream."
     return 1
   fi
-  chmod 0644 "${tmp}"
-  mv "${tmp}" "${VERSIONS}"
   ENV_UPDATES=$((ENV_UPDATES + 1))
   log "  updated ${key}=${val}"
 }

--- a/scripts/update-versions-env.py
+++ b/scripts/update-versions-env.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Atomically update existing versions.env values as validated data."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+from versions_env import VersionsEnvError, parse_versions_env
+
+
+def parse_assignments(assignments: list[str]) -> dict[str, str]:
+    updates = {}
+    for assignment in assignments:
+        if "=" not in assignment:
+            raise VersionsEnvError(
+                f"expected KEY=value assignment, got {assignment!r}"
+            )
+        key, value = assignment.split("=", 1)
+        if key in updates:
+            raise VersionsEnvError(f"duplicate update for {key}")
+        updates[key] = value
+    if not updates:
+        raise VersionsEnvError("at least one KEY=value update is required")
+    return updates
+
+
+def update_versions_text(text: str, updates: dict[str, str]) -> str:
+    current_values = parse_versions_env(text)
+    unknown = updates.keys() - current_values.keys()
+    if unknown:
+        raise VersionsEnvError(
+            "cannot update missing keys: " + ", ".join(sorted(unknown))
+        )
+
+    rendered = []
+    replaced = set()
+    for raw_line in text.splitlines(keepends=True):
+        content = raw_line.rstrip("\r\n")
+        line_ending = raw_line[len(content):]
+        if "=" in content:
+            key = content.split("=", 1)[0]
+            if key in updates:
+                raw_line = f"{key}={updates[key]}{line_ending}"
+                replaced.add(key)
+        rendered.append(raw_line)
+
+    missing = updates.keys() - replaced
+    if missing:
+        raise VersionsEnvError(
+            "could not replace keys: " + ", ".join(sorted(missing))
+        )
+    candidate = "".join(rendered)
+    parse_versions_env(candidate)
+    return candidate
+
+
+def atomic_update(path: Path, assignments: list[str]) -> None:
+    if path.is_symlink():
+        raise VersionsEnvError("refusing to replace a symlink")
+    text = path.read_text(encoding="utf-8")
+    candidate = update_versions_text(text, parse_assignments(assignments))
+    mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(candidate)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.chmod(mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    parser.add_argument("assignment", nargs="+")
+    args = parser.parse_args()
+    try:
+        atomic_update(args.path, args.assignment)
+    except (OSError, UnicodeError, VersionsEnvError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -1,15 +1,42 @@
 #!/usr/bin/env python3
 """Tests for check-updates.sh using deterministic mocked upstream APIs."""
 
+import importlib.util
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 
 SOURCE_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SOURCE_ROOT / "scripts"))
+MONITOR_POLICY_SPEC = importlib.util.spec_from_file_location(
+    "validate_monitor_update",
+    SOURCE_ROOT / "scripts" / "validate-monitor-update.py",
+)
+MONITOR_POLICY = importlib.util.module_from_spec(MONITOR_POLICY_SPEC)
+assert MONITOR_POLICY_SPEC.loader is not None
+MONITOR_POLICY_SPEC.loader.exec_module(MONITOR_POLICY)
+
+MONITOR_FIXTURE_BASELINE = {
+    "CUDA_BASE_DIGEST": (
+        "sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb"
+        "352d7652024047020"
+    ),
+    "FLASHINFER_REF": "v0.6.14",
+    "NCCL_REF": "v2.30.7-1",
+    "NUMBA_VERSION": "0.65.0",
+    "TILELANG_VERSION": "0.1.9",
+    "TORCHAUDIO_VERSION": "2.11.0",
+    "TORCHVISION_VERSION": "0.26.0",
+    "TORCH_VERSION": "2.11.0",
+    "TVM_FFI_VERSION": "0.1.10",
+    "UV_VERSION": "0.11.32",
+    "VLLM_REF": "v0.26.0",
+}
 
 FAKE_CURL = r'''#!/usr/bin/env python3
 import json
@@ -65,7 +92,18 @@ else:
 '''
 
 
-def setup_case(directory):
+def write_monitor_fixture_baseline(path):
+    text = path.read_text(encoding="utf-8")
+    current_values = parse_env(path)
+    assert set(MONITOR_FIXTURE_BASELINE) == MONITOR_POLICY.ALLOWED_UPDATE_KEYS
+    for key, value in MONITOR_FIXTURE_BASELINE.items():
+        current = f"{key}={current_values[key]}"
+        assert current in text
+        text = text.replace(current, f"{key}={value}", 1)
+    path.write_text(text, encoding="utf-8")
+
+
+def setup_case(directory, source_versions=None):
     root = Path(directory) / "repo"
     (root / "scripts").mkdir(parents=True)
     (root / "locks").mkdir()
@@ -75,7 +113,12 @@ def setup_case(directory):
         root / "scripts",
     )
     shutil.copy2(SOURCE_ROOT / "scripts" / "versions_env.py", root / "scripts")
-    shutil.copy2(SOURCE_ROOT / "versions.env", root / "versions.env")
+    versions = root / "versions.env"
+    if source_versions is None:
+        shutil.copy2(SOURCE_ROOT / "versions.env", versions)
+    else:
+        versions.write_text(source_versions, encoding="utf-8")
+    write_monitor_fixture_baseline(versions)
     shutil.copy2(
         SOURCE_ROOT / "locks" / "apt-sources.list",
         root / "locks" / "apt-sources.list",
@@ -125,6 +168,26 @@ def test_target_vllm_requirements_are_applied():
         assert values["TILELANG_VERSION"] == "9.5.0"
         assert values["NUMBA_VERSION"] == "9.4.0"
         assert (root / "versions.env").stat().st_mode & 0o777 == 0o644
+        assert "7 component(s) updated in versions.env" in result.stdout
+
+
+def test_repository_version_drift_does_not_change_fixture_results():
+    with tempfile.TemporaryDirectory() as directory:
+        source_versions = (SOURCE_ROOT / "versions.env").read_text(
+            encoding="utf-8"
+        )
+        current_uv = parse_env(SOURCE_ROOT / "versions.env")["UV_VERSION"]
+        source_versions = source_versions.replace(
+            f"UV_VERSION={current_uv}",
+            "UV_VERSION=0.12.0",
+            1,
+        )
+        root, env = setup_case(directory, source_versions)
+
+        assert parse_env(root / "versions.env")["UV_VERSION"] == "0.11.32"
+        result = run_check(root, env, "--update")
+
+        assert result.returncode == 0, result.stderr
         assert "7 component(s) updated in versions.env" in result.stdout
 
 
@@ -295,6 +358,7 @@ def test_mutating_modes_are_mutually_exclusive():
 def main():
     tests = [
         test_target_vllm_requirements_are_applied,
+        test_repository_version_drift_does_not_change_fixture_results,
         test_dry_run_does_not_write_versions,
         test_valid_update_crosses_fresh_runner_policy,
         test_current_stack_reports_no_updates,

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -112,6 +112,10 @@ def setup_case(directory, source_versions=None):
         SOURCE_ROOT / "scripts" / "validate-monitor-update.py",
         root / "scripts",
     )
+    shutil.copy2(
+        SOURCE_ROOT / "scripts" / "update-versions-env.py",
+        root / "scripts",
+    )
     shutil.copy2(SOURCE_ROOT / "scripts" / "versions_env.py", root / "scripts")
     versions = root / "versions.env"
     if source_versions is None:
@@ -189,6 +193,66 @@ def test_repository_version_drift_does_not_change_fixture_results():
 
         assert result.returncode == 0, result.stderr
         assert "7 component(s) updated in versions.env" in result.stdout
+
+
+def test_every_monitored_repository_value_is_normalized():
+    with tempfile.TemporaryDirectory() as directory:
+        source_versions = (SOURCE_ROOT / "versions.env").read_text(
+            encoding="utf-8"
+        )
+        source_values = parse_env(SOURCE_ROOT / "versions.env")
+        for key in MONITOR_POLICY.ALLOWED_UPDATE_KEYS:
+            if key == "CUDA_BASE_DIGEST":
+                drifted = "sha256:" + "9" * 64
+            elif key == "NCCL_REF":
+                drifted = "v88.77.66-1"
+            elif key.endswith("_REF"):
+                drifted = "v88.77.66"
+            else:
+                drifted = "88.77.66"
+            source_versions = source_versions.replace(
+                f"{key}={source_values[key]}",
+                f"{key}={drifted}",
+                1,
+            )
+
+        root, _ = setup_case(directory, source_versions)
+
+        values = parse_env(root / "versions.env")
+        for key, expected in MONITOR_FIXTURE_BASELINE.items():
+            assert values[key] == expected
+
+
+def test_fixture_preserves_non_monitored_values_and_structure():
+    with tempfile.TemporaryDirectory() as directory:
+        source_versions = (SOURCE_ROOT / "versions.env").read_text(
+            encoding="utf-8"
+        )
+        current_ray = parse_env(SOURCE_ROOT / "versions.env")["RAY_VERSION"]
+        source_versions = source_versions.replace(
+            f"RAY_VERSION={current_ray}",
+            "RAY_VERSION=88.77.66",
+            1,
+        )
+        root, _ = setup_case(directory, source_versions)
+        normalized = (root / "versions.env").read_text(encoding="utf-8")
+
+        assert parse_env(root / "versions.env")["RAY_VERSION"] == "88.77.66"
+        source_non_values = [
+            line for line in source_versions.splitlines()
+            if not any(
+                line.startswith(f"{key}=")
+                for key in MONITOR_POLICY.ALLOWED_UPDATE_KEYS
+            )
+        ]
+        normalized_non_values = [
+            line for line in normalized.splitlines()
+            if not any(
+                line.startswith(f"{key}=")
+                for key in MONITOR_POLICY.ALLOWED_UPDATE_KEYS
+            )
+        ]
+        assert normalized_non_values == source_non_values
 
 
 def test_dry_run_does_not_write_versions():
@@ -359,6 +423,8 @@ def main():
     tests = [
         test_target_vllm_requirements_are_applied,
         test_repository_version_drift_does_not_change_fixture_results,
+        test_every_monitored_repository_value_is_normalized,
+        test_fixture_preserves_non_monitored_values_and_structure,
         test_dry_run_does_not_write_versions,
         test_valid_update_crosses_fresh_runner_policy,
         test_current_stack_reports_no_updates,

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -160,7 +160,9 @@ def test_sensitive_paths_have_codeowners():
         "/versions.env",
         "/locks/",
         "/scripts/",
+        "/tests/test-monitor-lifecycle.py",
         "/tests/test-monitor-update-policy.py",
+        "/tests/test-update-versions-env.py",
         "/tests/test-versions-contract.py",
     ):
         assert f"{path} @timothystewart6" in codeowners

--- a/tests/test-monitor-lifecycle.py
+++ b/tests/test-monitor-lifecycle.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""End-to-end contracts for monitored inputs after a dependency PR is created."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MONITOR = load_module(
+    "validate_monitor_update",
+    "scripts/validate-monitor-update.py",
+)
+VERSIONS = load_module("versions_env", "scripts/versions_env.py")
+BUILD = load_module("compute_gb10_build", "scripts/compute-gb10-build.py")
+DUPLICATES = load_module(
+    "check_duplicate_pr",
+    "scripts/check-duplicate-pr.py",
+)
+DIFF = load_module("versions_diff", "scripts/versions_diff.py")
+
+BASE_TEXT = (ROOT / "versions.env").read_text(encoding="utf-8")
+BASE_VALUES = VERSIONS.parse_versions_env(BASE_TEXT)
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def replacement_for(key):
+    if key == "CUDA_BASE_DIGEST":
+        return "sha256:" + "1" * 64
+    if key == "NCCL_REF":
+        return "v99.88.77-1"
+    if key.endswith("_REF"):
+        return "v99.88.77"
+    return "99.88.77"
+
+
+def candidate_for(key):
+    old = f"{key}={BASE_VALUES[key]}"
+    assert old in BASE_TEXT
+    return BASE_TEXT.replace(old, f"{key}={replacement_for(key)}", 1)
+
+
+def test_every_monitored_change_survives_pr_contracts():
+    for key in MONITOR.ALLOWED_UPDATE_KEYS:
+        candidate = candidate_for(key)
+        assert MONITOR.validate_monitor_update(BASE_TEXT, candidate) == {key}
+        candidate_values = VERSIONS.parse_versions_env(candidate)
+        changes = DIFF.diff_env_dicts(BASE_VALUES, candidate_values)
+        assert changes == {
+            key: (BASE_VALUES[key], candidate_values[key])
+        }
+        assert key in DIFF.COMPONENT_LABELS
+        assert DIFF.format_change_lines(changes) == [
+            f"- **{DIFF.COMPONENT_LABELS[key]}**: "
+            f"{BASE_VALUES[key]} -> {candidate_values[key]}"
+        ]
+        unified = (
+            f"-{key}={BASE_VALUES[key]}\n"
+            f"+{key}={candidate_values[key]}\n"
+        )
+        assert DUPLICATES.diff_has_substantive_changes(unified)
+
+
+def test_every_monitored_change_has_build_revision_behavior():
+    assert "VLLM_REF" in VERSIONS.BUILD_RESET_INPUT_KEYS
+    ordinary = MONITOR.ALLOWED_UPDATE_KEYS - {"VLLM_REF"}
+    assert ordinary <= VERSIONS.BUILD_INCREMENT_INPUT_KEYS
+
+    for key in MONITOR.ALLOWED_UPDATE_KEYS:
+        if key == "VLLM_REF":
+            result = BUILD.compute_build_number(
+                old_vllm_ref=BASE_VALUES["VLLM_REF"],
+                new_vllm_ref=replacement_for(key),
+                old_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+                reviewed_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+                resolved_vllm_commit="1" * 40,
+                old_build=int(BASE_VALUES["GB10_BUILD"]),
+                other_input_changed=True,
+            )
+            assert result == 0
+        else:
+            result = BUILD.compute_build_number(
+                old_vllm_ref=BASE_VALUES["VLLM_REF"],
+                new_vllm_ref=BASE_VALUES["VLLM_REF"],
+                old_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+                reviewed_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+                resolved_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+                old_build=int(BASE_VALUES["GB10_BUILD"]),
+                other_input_changed=True,
+            )
+            assert result == int(BASE_VALUES["GB10_BUILD"]) + 1
+
+
+def test_every_monitored_change_reaches_build_and_release_metadata():
+    build_args = read("scripts/build-args.sh")
+    metadata = read("scripts/render-metadata.sh")
+    for key in MONITOR.ALLOWED_UPDATE_KEYS:
+        assert f"_arg {key}" in build_args
+        assert f"${{{key}}}" in metadata
+
+
+def test_uv_update_reaches_bootstrap_lock_and_advances_build():
+    bump = read("scripts/bump.sh")
+    assert "UV_VERSION" in VERSIONS.BUILD_INCREMENT_INPUT_KEYS
+    assert "uv==%s" in bump
+    assert '"${UV_VERSION}"' in bump
+    assert BUILD.compute_build_number(
+        old_vllm_ref=BASE_VALUES["VLLM_REF"],
+        new_vllm_ref=BASE_VALUES["VLLM_REF"],
+        old_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+        reviewed_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+        resolved_vllm_commit=BASE_VALUES["VLLM_COMMIT"],
+        old_build=3,
+        other_input_changed=True,
+    ) == 4
+
+
+def test_upstream_values_use_the_atomic_validated_writer():
+    check_updates = read("scripts/check-updates.sh")
+    bump = read("scripts/bump.sh")
+    helper = "scripts/update-versions-env.py"
+    assert helper in check_updates
+    assert helper in bump
+    assert not re.search(r"^\s*sed -i\b", check_updates, re.MULTILINE)
+    assert not re.search(r"^\s*sed -i\b", bump, re.MULTILINE)
+
+    resolved_outputs = {
+        "CUDA_BASE_DIGEST",
+        "GB10_BUILD",
+        "NCCL_COMMIT",
+        "VLLM_COMMIT",
+        "FLASHINFER_COMMIT",
+        "RAY_VERSION",
+    }
+    for key in resolved_outputs:
+        assert f'"{key}=${{{key}}}"' in bump
+
+
+def test_workflows_preserve_generated_pr_handoff_order():
+    monitor = read(".github/workflows/monitor-upstream-releases.yaml")
+    create_job = monitor.split("\n  create-pr:", 1)[1]
+    assert create_job.index("scripts/validate-monitor-update.py") < (
+        create_job.index("secrets.RELEASE_MONITOR_PAT")
+    )
+    assert "base: main" in create_job
+    assert "add-paths: versions.env" in create_job
+
+    bump = read(".github/workflows/run-bump.yaml")
+    ordered_bump_controls = (
+        "Verify integration branch still points to approved SHA",
+        "Import reviewed declarative inputs",
+        "Validate imported inputs with trusted validators",
+        "Run trusted bump.sh",
+        "Preserve generated outputs",
+        "Apply outputs to exact approved commit",
+        "Validate generated changes",
+        "Commit generated files",
+        "Recheck branch and push",
+    )
+    positions = [bump.index(control) for control in ordered_bump_controls]
+    assert positions == sorted(positions)
+
+    build = read(".github/workflows/build-image.yaml")
+    trigger = build.split("\npermissions:", 1)[0]
+    assert "- versions.env" in trigger
+    assert build.index("Validate versions.env") < build.index(
+        "Source versions.env into GITHUB_ENV"
+    )
+
+
+def test_lifecycle_guidance_is_visible_to_agents_and_humans():
+    anchor = "automated-release-monitor-lifecycle"
+    assert anchor in read("AGENTS.md")
+    assert "## Automated release monitor lifecycle" in read("CONTRIBUTING.md")
+    assert anchor in read("docs/contributor-ci-security.md")
+
+
+def main():
+    tests = [
+        test_every_monitored_change_survives_pr_contracts,
+        test_every_monitored_change_has_build_revision_behavior,
+        test_every_monitored_change_reaches_build_and_release_metadata,
+        test_uv_update_reaches_bootstrap_lock_and_advances_build,
+        test_upstream_values_use_the_atomic_validated_writer,
+        test_workflows_preserve_generated_pr_handoff_order,
+        test_lifecycle_guidance_is_visible_to_agents_and_humans,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} monitor lifecycle tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-update-versions-env.py
+++ b/tests/test-update-versions-env.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Security and atomicity tests for update-versions-env.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+SPEC = importlib.util.spec_from_file_location(
+    "update_versions_env",
+    ROOT / "scripts" / "update-versions-env.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+BASE_TEXT = (ROOT / "versions.env").read_text(encoding="utf-8")
+
+
+def assert_rejected(updates, reason):
+    try:
+        MODULE.update_versions_text(BASE_TEXT, updates)
+    except MODULE.VersionsEnvError:
+        return
+    raise AssertionError(f"accepted unsafe update: {reason}")
+
+
+def test_single_update_preserves_all_other_bytes():
+    candidate = MODULE.update_versions_text(BASE_TEXT, {"UV_VERSION": "9.8.7"})
+    expected = BASE_TEXT.replace(
+        "UV_VERSION=" + MODULE.parse_versions_env(BASE_TEXT)["UV_VERSION"],
+        "UV_VERSION=9.8.7",
+        1,
+    )
+    assert candidate == expected
+
+
+def test_multiple_updates_are_one_valid_candidate():
+    candidate = MODULE.update_versions_text(
+        BASE_TEXT,
+        {
+            "UV_VERSION": "9.8.7",
+            "RAY_VERSION": "9.8.7",
+            "GB10_BUILD": "42",
+            "VLLM_COMMIT": "1" * 40,
+        },
+    )
+    values = MODULE.parse_versions_env(candidate)
+    assert values["UV_VERSION"] == "9.8.7"
+    assert values["RAY_VERSION"] == "9.8.7"
+    assert values["GB10_BUILD"] == "42"
+    assert values["VLLM_COMMIT"] == "1" * 40
+
+
+def test_invalid_batch_does_not_modify_file():
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "versions.env"
+        path.write_text(BASE_TEXT, encoding="utf-8")
+        before = path.read_bytes()
+        try:
+            MODULE.atomic_update(
+                path,
+                ["UV_VERSION=9.8.7", "RAY_VERSION=9.8.7|e"],
+            )
+        except MODULE.VersionsEnvError:
+            pass
+        else:
+            raise AssertionError("accepted one invalid value in an update batch")
+        assert path.read_bytes() == before
+        assert list(path.parent.iterdir()) == [path]
+
+
+def test_atomic_update_preserves_file_mode():
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "versions.env"
+        path.write_text(BASE_TEXT, encoding="utf-8")
+        path.chmod(0o640)
+        MODULE.atomic_update(path, ["UV_VERSION=9.8.7"])
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+
+def test_assignment_parser_rejects_ambiguous_inputs():
+    rejected = (
+        [],
+        ["UV_VERSION"],
+        ["UV_VERSION=9.8.7", "UV_VERSION=9.8.8"],
+    )
+    for assignments in rejected:
+        try:
+            MODULE.parse_assignments(assignments)
+        except MODULE.VersionsEnvError:
+            continue
+        raise AssertionError(f"accepted ambiguous assignments: {assignments}")
+
+
+def test_unknown_and_missing_keys_are_rejected():
+    assert_rejected({"UNKNOWN_VERSION": "1.2.3"}, "unknown key")
+    assert_rejected({"": "1.2.3"}, "empty key")
+
+
+def test_shell_python_sed_and_multiline_payloads_are_rejected():
+    payloads = (
+        "$(touch /tmp/owned)",
+        "`touch /tmp/owned`",
+        "9.8.7|e",
+        "9.8.7|w /tmp/owned",
+        "9.8.7';__import__('os').system('id')#",
+        "9.8.7\nEVIL=value",
+        "9.8.7\rEVIL=value",
+        "${PATH}",
+        "9.8.7;id",
+        "9.8.7%0AATTACK=value",
+        "9.8.7\u202eattack",
+        "a" * 4097,
+    )
+    for payload in payloads:
+        assert_rejected({"UV_VERSION": payload}, payload)
+
+
+def test_type_specific_validation_still_applies():
+    cases = (
+        {"GB10_BUILD": "-1"},
+        {"GB10_BUILD": "1000001"},
+        {"VLLM_COMMIT": "1" * 39},
+        {"VLLM_REF": "main"},
+        {"CUDA_BASE_DIGEST": "sha256:" + "z" * 64},
+        {"CUDA_BASE_IMAGE": "attacker.invalid/cuda:latest"},
+        {"PYPI_INDEX_URL": "https://attacker.invalid/simple"},
+    )
+    for updates in cases:
+        assert_rejected(updates, str(updates))
+
+
+def test_symlink_target_is_rejected():
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        target = root / "target.env"
+        link = root / "versions.env"
+        target.write_text(BASE_TEXT, encoding="utf-8")
+        link.symlink_to(target)
+        before = target.read_bytes()
+        try:
+            MODULE.atomic_update(link, ["UV_VERSION=9.8.7"])
+        except MODULE.VersionsEnvError:
+            pass
+        else:
+            raise AssertionError("updated versions.env through a symlink")
+        assert target.read_bytes() == before
+
+
+def test_atomic_replace_does_not_leave_temporary_files():
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "versions.env"
+        path.write_text(BASE_TEXT, encoding="utf-8")
+        MODULE.atomic_update(path, ["UV_VERSION=9.8.7"])
+        assert [entry.name for entry in path.parent.iterdir()] == ["versions.env"]
+
+
+def main():
+    tests = [
+        test_single_update_preserves_all_other_bytes,
+        test_multiple_updates_are_one_valid_candidate,
+        test_invalid_batch_does_not_modify_file,
+        test_atomic_update_preserves_file_mode,
+        test_assignment_parser_rejects_ambiguous_inputs,
+        test_unknown_and_missing_keys_are_rejected,
+        test_shell_python_sed_and_multiline_payloads_are_rejected,
+        test_type_specific_validation_still_applies,
+        test_symlink_target_is_rejected,
+        test_atomic_replace_does_not_leave_temporary_files,
+    ]
+    for test in tests:
+        test()
+        print(f"PASS: {test.__name__}")
+    print(f"All {len(tests)} atomic versions update tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-versions-contract.py
+++ b/tests/test-versions-contract.py
@@ -122,12 +122,16 @@ def test_repository_onboarding_is_visible_and_enforced():
 def test_agent_instructions_have_one_canonical_source():
     agents = read("AGENTS.md")
     claude = read("CLAUDE.md")
+    copilot = read(".github/copilot-instructions.md")
     codeowners = read(".github/CODEOWNERS")
 
     assert "canonical repository instruction source" in agents
     assert claude.startswith("@AGENTS.md\n")
     assert len(claude.encode("utf-8")) < 512
+    assert "[AGENTS.md](../AGENTS.md)" in copilot
+    assert len(copilot.encode("utf-8")) < 512
     assert "/CLAUDE.md @timothystewart6" in codeowners
+    assert "/.github/copilot-instructions.md @timothystewart6" in codeowners
 
 
 def test_hosted_ci_discovers_every_python_test():

--- a/tests/test-versions-contract.py
+++ b/tests/test-versions-contract.py
@@ -92,6 +92,33 @@ def test_guidance_is_visible_to_humans_agents_and_reviewers():
     assert anchor in read(".github/PULL_REQUEST_TEMPLATE.md")
 
 
+def test_repository_onboarding_is_visible_and_enforced():
+    guide = "docs/repository-guide.md"
+    agents = read("AGENTS.md")
+    contributing = read("CONTRIBUTING.md")
+    pull_request = read(".github/PULL_REQUEST_TEMPLATE.md")
+    bug_report = read(".github/ISSUE_TEMPLATE/bug_report.yml")
+    version_bump = read(".github/ISSUE_TEMPLATE/version_bump.yml")
+    codeowners = read(".github/CODEOWNERS")
+
+    assert guide in agents
+    assert guide in contributing
+    assert guide in read("README.md")
+    assert "/.github/ISSUE_TEMPLATE/ @timothystewart6" in codeowners
+    assert "/docs/repository-guide.md @timothystewart6" in codeowners
+    for section in (
+        "## Reasoning and evidence",
+        "## Lifecycle impact",
+        "## Security impact",
+        "## Validation",
+    ):
+        assert section in pull_request
+    for template in (bug_report, version_bump):
+        assert "open and closed issues and pull requests" in template
+        assert "id: related-work" in template
+        assert "id: preflight" in template
+
+
 def test_hosted_ci_discovers_every_python_test():
     workflow = read(".github/workflows/test-release-notes.yaml")
     assert "for test_file in tests/test-*.py" in workflow
@@ -105,6 +132,7 @@ def main():
         test_every_version_has_a_label_and_release_metadata,
         test_every_version_has_a_trusted_build_consumer,
         test_guidance_is_visible_to_humans_agents_and_reviewers,
+        test_repository_onboarding_is_visible_and_enforced,
         test_hosted_ci_discovers_every_python_test,
     ]
     for test in tests:

--- a/tests/test-versions-contract.py
+++ b/tests/test-versions-contract.py
@@ -119,6 +119,17 @@ def test_repository_onboarding_is_visible_and_enforced():
         assert "id: preflight" in template
 
 
+def test_agent_instructions_have_one_canonical_source():
+    agents = read("AGENTS.md")
+    claude = read("CLAUDE.md")
+    codeowners = read(".github/CODEOWNERS")
+
+    assert "canonical repository instruction source" in agents
+    assert claude.startswith("@AGENTS.md\n")
+    assert len(claude.encode("utf-8")) < 512
+    assert "/CLAUDE.md @timothystewart6" in codeowners
+
+
 def test_hosted_ci_discovers_every_python_test():
     workflow = read(".github/workflows/test-release-notes.yaml")
     assert "for test_file in tests/test-*.py" in workflow
@@ -133,6 +144,7 @@ def main():
         test_every_version_has_a_trusted_build_consumer,
         test_guidance_is_visible_to_humans_agents_and_reviewers,
         test_repository_onboarding_is_visible_and_enforced,
+        test_agent_instructions_have_one_canonical_source,
         test_hosted_ci_discovers_every_python_test,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary

- normalize every release-monitor input to a deterministic test baseline
- require fixture coverage to equal the production monitor allowlist
- validate every monitored change through PR formatting, bump accounting, build arguments, and release metadata
- replace external-data `sed` writes with an atomic schema-validating versions writer
- document the generated dependency PR lifecycle for agents and maintainers
- require evidence-first repository onboarding before issues, code changes, and pull requests

## Root cause

`test-check-updates.py` copied the repository's live `versions.env` while its
mocked upstream responses and expected update count assumed older fixed values.
PR #72 changed UV from `0.11.32` to `0.12.0`, so the mock attempted a downgrade
and invalidated the expected count.

The missing acceptance criterion was testing the complete hosted suite against
the repository state after a representative generated update. A successful
monitor run proves detection and PR creation, but not that the generated PR is
compatible with its tests or downstream automation.

## Security and downstream review

The review followed the generated PR into `run-bump.yaml`, `bump.sh`,
`build-image.yaml`, build arguments, lock generation, and release metadata.
The trusted-main and exact-reviewed-SHA boundaries remain unchanged.

The review also found that `bump.sh` still constructed a `sed` program from
externally resolved values before validating the result. Both monitor and bump
now pass values as data to a shared writer that validates the complete
candidate, writes it atomically, preserves mode and structure, rejects
symlinks, and leaves the original file untouched on failure.

## Regression protection

- exact PR #72 `UV_VERSION=0.12.0` drift regression
- all monitored keys normalized independently of production values
- allowlist and deterministic fixture equality
- all monitored keys validated through PR labels and duplicate detection
- reset or increment behavior for every monitored build input
- build argument and release metadata coverage for every monitored key
- UV bootstrap-lock and build-number coverage
- adversarial shell, Python, sed, multiline, Unicode, URL, digest, SHA, and size payloads
- duplicate, unknown, missing, symlink, atomic rollback, mode, and temporary-file cases
- monitor to bump to build workflow handoff ordering
- CODEOWNERS coverage for the new lifecycle and writer tests

## Contributor and agent onboarding

- adds a repository map connecting inputs, validation, generation, build, verification, and release output
- keeps `AGENTS.md` canonical, imports it from `CLAUDE.md`, and points Copilot-only surfaces to it
- requires agents to inspect callers, consumers, tests, history, related issues, PRs, and workflow runs
- requires an invariant, evidence, bounded root-cause hypothesis, lifecycle impact, security impact, and validation plan
- expands issue forms with expected and actual behavior, related work, and preflight confirmation
- expands the pull request template with reasoning, lifecycle, security, and validation sections
- protects the guidance and templates with CODEOWNERS and a hosted contract test

## Validation

- every `tests/test-*.py` suite against this branch
- every `tests/test-*.py` suite against a copied repository with the exact generated `UV_VERSION=0.12.0` change applied
- `actionlint .github/workflows/*.yaml`
- `bash -n scripts/*.sh tests/*.sh`
- `shellcheck -S warning scripts/*.sh tests/*.sh`
- `python3 -m py_compile scripts/*.py tests/*.py`
- YAML parsing for both issue forms
- `git diff --check`

Related failure: https://github.com/timothystewart6/vllm-gb10/actions/runs/30400555286/job/90414032516
