### PR TITLE
fix(docker): use pinned tokenizer mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -236,12 +236,13 @@ COPY locks/python-runtime.txt /tmp/python-runtime.txt
 
 WORKDIR /workspace
 
-# Tiktoken encodings - static blobs from OpenAI, verified against committed
-# checksums so the build fails loudly if upstream ever changes the bytes.
+# Tiktoken encodings - static blobs mirrored in Microsoft's official ML.NET
+# repository at a pinned commit, verified against committed checksums so the
+# build fails loudly if the mirror ever changes the bytes.
 COPY checksums/tiktoken.sha256 /tmp/tiktoken.sha256
 RUN mkdir -p tiktoken_encodings \
- && wget -O tiktoken_encodings/o200k_base.tiktoken  https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken \
- && wget -O tiktoken_encodings/cl100k_base.tiktoken https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken \
+ && wget -O tiktoken_encodings/o200k_base.tiktoken  https://raw.githubusercontent.com/dotnet/machinelearning/efefa92f4486a43047c5b47618885a71bf7f0967/src/Microsoft.ML.Tokenizers.Data.O200kBase/Data/o200k_base.tiktoken \
+ && wget -O tiktoken_encodings/cl100k_base.tiktoken https://raw.githubusercontent.com/dotnet/machinelearning/efefa92f4486a43047c5b47618885a71bf7f0967/src/Microsoft.ML.Tokenizers.Data.Cl100kBase/Data/cl100k_base.tiktoken \
  && cd tiktoken_encodings && sha256sum -c /tmp/tiktoken.sha256
 ENV TIKTOKEN_ENCODINGS_BASE=/workspace/tiktoken_encodings
 

--- a/versions.env
+++ b/versions.env
@@ -16,7 +16,7 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76520
 # Image stack revision.
 # Reset to 0 each time VLLM_REF bumps to a new minor/patch.
 # Incremented by bump.sh when any non-vLLM input changes on the same VLLM_REF.
-GB10_BUILD=5
+GB10_BUILD=6
 
 # ---------------------------------------------------------------------------
 # Python / uv bootstrap


### PR DESCRIPTION
### Problem

The post-merge image build failed because the OpenAI tokenizer blob endpoint returned HTTP 404: the specified storage account does not exist.

### Change

- Use byte-identical tokenizer files from Microsoft's official ML.NET repository at pinned commit efefa92f4486a43047c5b47618885a71bf7f0967.
- Preserve the committed SHA-256 verification for both files.

### Validation

- All 102 repository test checks pass.
- Both replacement files match the existing checksums.
- The DGX Spark Docker smoke build remains to be validated by hosted CI.

Failure run: https://github.com/timothystewart6/vllm-gb10/actions/runs/30703931506