### PR TITLE
fix(gx10): coordinate model lifecycle

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,5 @@
 self-hosted-runner:
   labels:
     - dgx-spark
+    - gb10-1
+    - gb10-2

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -10,10 +10,12 @@
 #
 # Job layout (split so re-runs of cheap stages don't require a 1-hour rebuild):
 #
-#   build    -> compile + push image to GHCR (the expensive job; cached to
-#               ghcr.io/.../:buildcache so re-runs are near-instant cache hits)
-#   verify   -> needs: build. Pull image, smoke test, extract artifacts.
-#   release  -> needs: verify. Push git release tag, mirror image to Docker Hub.
+#   stop-model  -> stop the existing two-node model engine to release RAM.
+#   build       -> compile + push image to GHCR (the expensive job; cached to
+#                  ghcr.io/.../:buildcache so re-runs are near-instant hits).
+#   start-model -> restart both model-engine containers, even after failure.
+#   verify      -> pull image, smoke test, extract artifacts.
+#   release     -> push git release tag, mirror image to Docker Hub.
 #
 # Re-run "verify" or "release" from the Actions UI to retry without rebuilding.
 
@@ -32,15 +34,41 @@ on:
       - checksums/**
       - tests/**
 
-# No workflow-level concurrency limit: each self-hosted runner handles exactly
-# one job at a time (GitHub enforces this), so two Sparks can build in parallel.
+concurrency:
+  group: build-image-model-lifecycle
+  cancel-in-progress: false
 
 permissions:
   contents: write
   packages: write
 
 jobs:
+  stop-model:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: gb10-1
+            container: vllm-ray-head
+          - runner: gb10-2
+            container: vllm-ray-worker
+    runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]
+
+    steps:
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Refusing to run GX10 jobs from a non-main workflow ref."
+            exit 1
+          fi
+
+      - name: Stop model container
+        run: docker stop "${{ matrix.container }}"
+
   build:
+    needs: stop-model
     runs-on: [self-hosted, linux, ARM64, dgx-spark]
     outputs:
       vllm_ref: ${{ steps.vars.outputs.vllm_ref }}
@@ -60,9 +88,6 @@ jobs:
             echo "Refusing to run GX10 jobs from a non-main workflow ref."
             exit 1
           fi
-
-      - name: Stop vLLM containers
-        run: docker stop vllm-ray-head vllm-ray-worker 2>/dev/null || true
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -206,12 +231,34 @@ jobs:
             FLASHINFER_CUDA_ARCH_LIST=${{ env.FLASHINFER_CUDA_ARCH_LIST }}
             SOURCE_DATE_EPOCH=${{ env.SOURCE_DATE_EPOCH }}
 
-      - name: Start vLLM containers
-        if: always()
-        run: docker start vllm-ray-head vllm-ray-worker 2>/dev/null || true
+  start-model:
+    needs: build
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: gb10-1
+            container: vllm-ray-head
+          - runner: gb10-2
+            container: vllm-ray-worker
+    runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]
+
+    steps:
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Refusing to run GX10 jobs from a non-main workflow ref."
+            exit 1
+          fi
+
+      - name: Start model container
+        run: docker start "${{ matrix.container }}"
 
   verify:
-    needs: build
+    needs: [build, start-model]
     runs-on: [self-hosted, linux, ARM64, dgx-spark]
     env:
       CANONICAL_IMAGE: ghcr.io/timothystewart6/vllm-gb10:${{ needs.build.outputs.canonical_tag }}

--- a/.github/workflows/verify-reproducible.yaml
+++ b/.github/workflows/verify-reproducible.yaml
@@ -36,14 +36,39 @@ on:
 
 # No packages: write needed - both builds are local only, never pushed.
 concurrency:
-  group: dgx-spark
+  group: build-image-model-lifecycle
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
+  stop-model:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: gb10-1
+            container: vllm-ray-head
+          - runner: gb10-2
+            container: vllm-ray-worker
+    runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]
+
+    steps:
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Refusing to run GX10 jobs from a non-main workflow ref."
+            exit 1
+          fi
+
+      - name: Stop model container
+        run: docker stop "${{ matrix.container }}"
+
   verify:
+    needs: stop-model
     runs-on: [self-hosted, linux, ARM64, dgx-spark]
 
     steps:
@@ -229,3 +254,29 @@ jobs:
           name: verify-reproducible-${{ github.run_id }}
           path: /tmp/verify/
           if-no-files-found: error
+
+  start-model:
+    needs: verify
+    if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: gb10-1
+            container: vllm-ray-head
+          - runner: gb10-2
+            container: vllm-ray-worker
+    runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]
+
+    steps:
+      - name: Require main
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Refusing to run GX10 jobs from a non-main workflow ref."
+            exit 1
+          fi
+
+      - name: Start model container
+        run: docker start "${{ matrix.container }}"

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -92,6 +92,43 @@ def test_trusted_builds_checkout_the_exact_event_sha():
         assert "ref: ${{ github.sha }}" in workflow, name
 
 
+def test_build_coordinates_model_lifecycle_across_both_gb10_nodes():
+    workflow = read(WORKFLOWS / "build-image.yaml")
+    stop_job = workflow.split("\n  stop-model:", 1)[1].split(
+        "\n  build:", 1
+    )[0]
+    build_job = workflow.split("\n  build:", 1)[1].split(
+        "\n  start-model:", 1
+    )[0]
+    start_job = workflow.split("\n  start-model:", 1)[1].split(
+        "\n  verify:", 1
+    )[0]
+    verify_job = workflow.split("\n  verify:", 1)[1].split(
+        "\n  release:", 1
+    )[0]
+
+    assert "group: build-image-model-lifecycle" in workflow
+    assert "cancel-in-progress: false" in workflow
+    for job in (stop_job, start_job):
+        assert "runner: gb10-1" in job
+        assert "container: vllm-ray-head" in job
+        assert "runner: gb10-2" in job
+        assert "container: vllm-ray-worker" in job
+        assert 'runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]' in job
+        assert "fail-fast: false" in job
+        assert "Require main" in job
+    assert 'docker stop "${{ matrix.container }}"' in stop_job
+    assert "|| true" not in stop_job
+    assert "needs: stop-model" in build_job
+    assert "docker stop" not in build_job
+    assert "docker start" not in build_job
+    assert "needs: build" in start_job
+    assert "if: always()" in start_job
+    assert 'docker start "${{ matrix.container }}"' in start_job
+    assert "|| true" not in start_job
+    assert "needs: [build, start-model]" in verify_job
+
+
 def test_privileged_workflows_reject_untrusted_refs():
     monitor = read(WORKFLOWS / "monitor-upstream-releases.yaml")
     assert 'WORKFLOW_REF: ${{ github.ref }}' in monitor
@@ -303,6 +340,7 @@ def main():
         test_all_external_actions_are_pinned_by_full_sha,
         test_bump_workflow_preserves_approval_boundary,
         test_trusted_builds_checkout_the_exact_event_sha,
+        test_build_coordinates_model_lifecycle_across_both_gb10_nodes,
         test_privileged_workflows_reject_untrusted_refs,
         test_monitor_pr_creation_is_scoped_and_handles_detached_checkout,
         test_pr_workflows_are_read_only_and_secret_free,

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -129,6 +129,36 @@ def test_build_coordinates_model_lifecycle_across_both_gb10_nodes():
     assert "needs: [build, start-model]" in verify_job
 
 
+def test_reproducibility_build_coordinates_model_lifecycle():
+    workflow = read(WORKFLOWS / "verify-reproducible.yaml")
+    stop_job = workflow.split("\n  stop-model:", 1)[1].split(
+        "\n  verify:", 1
+    )[0]
+    verify_job = workflow.split("\n  verify:", 1)[1].split(
+        "\n  start-model:", 1
+    )[0]
+    start_job = workflow.split("\n  start-model:", 1)[1]
+
+    assert "group: build-image-model-lifecycle" in workflow
+    assert "cancel-in-progress: false" in workflow
+    for job in (stop_job, start_job):
+        assert "runner: gb10-1" in job
+        assert "container: vllm-ray-head" in job
+        assert "runner: gb10-2" in job
+        assert "container: vllm-ray-worker" in job
+        assert 'runs-on: [self-hosted, linux, ARM64, "${{ matrix.runner }}"]' in job
+        assert "fail-fast: false" in job
+        assert "Require main" in job
+        assert "|| true" not in job
+    assert 'docker stop "${{ matrix.container }}"' in stop_job
+    assert "needs: stop-model" in verify_job
+    assert "docker stop" not in verify_job
+    assert "docker start" not in verify_job
+    assert "needs: verify" in start_job
+    assert "if: always()" in start_job
+    assert 'docker start "${{ matrix.container }}"' in start_job
+
+
 def test_privileged_workflows_reject_untrusted_refs():
     monitor = read(WORKFLOWS / "monitor-upstream-releases.yaml")
     assert 'WORKFLOW_REF: ${{ github.ref }}' in monitor
@@ -341,6 +371,7 @@ def main():
         test_bump_workflow_preserves_approval_boundary,
         test_trusted_builds_checkout_the_exact_event_sha,
         test_build_coordinates_model_lifecycle_across_both_gb10_nodes,
+        test_reproducibility_build_coordinates_model_lifecycle,
         test_privileged_workflows_reject_untrusted_refs,
         test_monitor_pr_creation_is_scoped_and_handles_detached_checkout,
         test_pr_workflows_are_read_only_and_secret_free,


### PR DESCRIPTION
Native GB10 builds need unified memory currently held by both ranks of the distributed model engine. Stopping only the container on the selected build runner leaves the other rank in a stale process group and can prevent a clean restart.

- stop the head and worker containers on their assigned node runners before image and reproducibility builds
- serialize both native-build workflows while model memory is reserved
- restart both ranks after each build, including failed builds
- enforce lifecycle contracts and register the custom runner labels with actionlint