### PR TITLE
fix(monitor): accept post-release refs in versions.env schema

### DIFF
--- a/scripts/versions_env.py
+++ b/scripts/versions_env.py
@@ -26,7 +26,7 @@ MAX_VALUE_LENGTH = 2048
 HEX_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)+(?:[.-][A-Za-z0-9]+)*$")
-REF_RE = re.compile(r"^v[0-9]+(?:\.[0-9]+)+(?:-[0-9]+)?$")
+REF_RE = re.compile(r"^v[0-9]+(?:\.[0-9]+)+(?:\.post[0-9]+)?(?:-[0-9]+)?$")
 CUDA_IMAGE_RE = re.compile(
     r"^nvidia/cuda:[0-9]+\.[0-9]+\.[0-9]+-devel-ubuntu24\.04$"
 )

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -58,7 +58,7 @@ torchaudio==9.7.0
 apache-tvm-ffi==9.6.0
 tilelang==9.5.0
 numba==9.4.0
-flashinfer-python==9.3.0""")
+flashinfer-python==9.3.0.post2""")
     else:
         print("""torch==2.11.0
 torchvision==0.26.0
@@ -164,7 +164,7 @@ def test_target_vllm_requirements_are_applied():
         assert result.returncode == 0, result.stderr
         values = parse_env(root / "versions.env")
         assert values["VLLM_REF"] == "v0.26.0"
-        assert values["FLASHINFER_REF"] == "v9.3.0"
+        assert values["FLASHINFER_REF"] == "v9.3.0.post2"
         assert values["TORCH_VERSION"] == "9.9.0"
         assert values["TORCHVISION_VERSION"] == "9.8.0"
         assert values["TORCHAUDIO_VERSION"] == "9.7.0"

--- a/tests/test-versions-env.py
+++ b/tests/test-versions-env.py
@@ -103,6 +103,13 @@ def main():
         replace_value(valid, "TORCH_CUDA_ARCH_LIST", "12.1a+9.0"),
         "unexpected GPU architecture",
     )
+    VERSIONS_ENV.parse_versions_env(
+        replace_value(valid, "FLASHINFER_REF", "v0.6.16.post3")
+    )
+    expect_rejected(
+        replace_value(valid, "FLASHINFER_REF", "v0.6.17rc5"),
+        "pre-release ref",
+    )
     print("All versions.env security tests passed!")
 
 


### PR DESCRIPTION
Fixes #87.

## Invariant

A `versions.env` release ref is accepted when it is a released upstream tag, and rejected otherwise. `REF_RE` implemented "released tag" as `^v[0-9]+(?:\.[0-9]+)+(?:-[0-9]+)?$`, which covers NCCL's `v2.30.7-1` but has no form for a PEP 440 post-release. vLLM `v0.27.0` pins `flashinfer-python==0.6.16.post3`, so `check-updates.sh` derived `FLASHINFER_REF=v0.6.16.post3` and `update-versions-env.py` rejected a genuine release tag, aborting [Monitor Upstream Releases #71](https://github.com/timothystewart6/vllm-gb10/actions/runs/31464881737) with exit 1 and holding back the already-detected `VLLM_REF=v0.27.0` and `NCCL_REF=v2.31.2-1`.

## Change

```diff
-REF_RE = re.compile(r"^v[0-9]+(?:\.[0-9]+)+(?:-[0-9]+)?$")
+REF_RE = re.compile(r"^v[0-9]+(?:\.[0-9]+)+(?:\.post[0-9]+)?(?:-[0-9]+)?$")
```

## Regression tests

`tests/test-check-updates.py` — the `FAKE_CURL` target-requirements fixture now pins `flashinfer-python==9.3.0.post2` instead of `9.3.0`, matching the shape vLLM actually publishes today, and the assertion expects `FLASHINFER_REF=v9.3.0.post2`. Without the schema change this test fails through the real detection path with the production error:

```
update-versions-env.py: error: FLASHINFER_REF must be a released v-prefixed tag
[check-updates] Rejected unsafe FLASHINFER_REF candidate from upstream.
```

`tests/test-versions-env.py` — asserts the schema boundary directly: `v0.6.16.post3` parses, `v0.6.17rc5` is still rejected.

## Validation

Run on Ubuntu 24.04, Python 3.12.3, against `ed55c03`.

| Check | Result |
|---|---|
| `for f in tests/test-*.py; do python3 "$f"; done` — before the change | 17/17 pass |
| same suite — after the change | 17/17 pass |
| same suite — with the candidate applied (`VLLM_REF=v0.27.0`, `NCCL_REF=v2.31.2-1`, `FLASHINFER_REF=v0.6.16.post3`) | 17/17 pass, `python3 scripts/versions_env.py versions.env` → `Validated versions.env` |
| `tests/test-check-updates.py` and `tests/test-versions-env.py` with the schema change reverted | both fail for the original reason |
| `bash -n scripts/*.sh tests/*.sh`, `python3 -m py_compile scripts/*.py tests/*.py`, `git diff --check` | clean |

Not run: `shellcheck` and `actionlint` were unavailable in my environment. No shell script or workflow file is touched by this change. No DGX Spark, credentialed, or image-build validation was performed; the change is confined to input policy and its tests, so the remaining stages are the hosted suite and the normal monitor run.

## Security

This widens an untrusted-input boundary, so the accepted shape stays narrow:

- only a literal `.post` followed by digits is added; pre-release suffixes (`rc`, `a`, `b`, `dev`) remain rejected, so the error message's "released" semantics still hold.
- `VALUE_RE` and `MAX_VALUE_LENGTH` still bound the character set and length before `REF_RE` runs, so no shell metacharacter or separator becomes reachable.
- a ref alone does not select the build input: `FLASHINFER_COMMIT` must be a 40-character SHA, and the `Dockerfile` asserts `git rev-parse HEAD` equals it after checking out `FLASHINFER_REF`, so a moved or ambiguous tag still fails the build.
- the monitor boundary is unchanged: `validate-monitor-update.py` still restricts a generated candidate to the monitored key allowlist, byte-for-byte on everything else.
