### PR TITLE
chore(deps): bump upstream dependencies

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -29,8 +29,8 @@ UV_VERSION=0.12.3
 # VLLM_COMMIT. torchvision/torchaudio/triton are the cu130 releases
 # tested compatible with that torch on aarch64 + CUDA 13.2.
 # ---------------------------------------------------------------------------
-TORCH_VERSION=2.11.0
-TORCHVISION_VERSION=0.26.0
+TORCH_VERSION=2.13.0
+TORCHVISION_VERSION=0.28.0
 TORCHAUDIO_VERSION=2.11.0
 TRITON_VERSION=3.6.0
 PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu130
@@ -43,8 +43,8 @@ FLASHINFER_INDEX_URL=https://flashinfer.ai/whl
 # requires at VLLM_REF (check requirements/cuda.txt at that commit).
 # ---------------------------------------------------------------------------
 NVSHMEM_VERSION=3.4.5
-TVM_FFI_VERSION=0.1.10
-TILELANG_VERSION=0.1.9
+TVM_FFI_VERSION=0.1.11
+TILELANG_VERSION=0.1.12
 NUMBA_VERSION=0.65.0
 
 # ---------------------------------------------------------------------------
@@ -52,7 +52,7 @@ NUMBA_VERSION=0.65.0
 # Tags can be force-moved; the SHA is what makes the build reproducible.
 # ---------------------------------------------------------------------------
 NCCL_REPO=https://github.com/NVIDIA/nccl.git
-NCCL_REF=v2.30.7-1
+NCCL_REF=v2.31.2-1
 NCCL_COMMIT=73cf112295c33aee2b895f329f592f2a9b4b0f97
 
 # ---------------------------------------------------------------------------
@@ -60,14 +60,14 @@ NCCL_COMMIT=73cf112295c33aee2b895f329f592f2a9b4b0f97
 # Rule: highest released tag that is at least 7 days old (lets dust settle).
 # ---------------------------------------------------------------------------
 VLLM_REPO=https://github.com/vllm-project/vllm.git
-VLLM_REF=v0.26.0
+VLLM_REF=v0.27.1
 VLLM_COMMIT=568afb3a13806beb53bb2e6bd518269357b237c0
 
 # ---------------------------------------------------------------------------
 # FlashInfer - pin by tag matching vLLM's requirements/cuda.txt pin.
 # ---------------------------------------------------------------------------
 FLASHINFER_REPO=https://github.com/flashinfer-ai/flashinfer.git
-FLASHINFER_REF=v0.6.14
+FLASHINFER_REF=v0.6.16.post3
 FLASHINFER_COMMIT=19f1a41e6b21f0c422d775e377b6fdf9a1fc9d23
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changes in this PR

- **FlashInfer**: v0.6.14 -> v0.6.16.post3
- **NCCL**: v2.30.7-1 -> v2.31.2-1
- **TileLang**: 0.1.9 -> 0.1.12
- **torchvision**: 0.26.0 -> 0.28.0
- **PyTorch**: 2.11.0 -> 2.13.0
- **TVM-FFI**: 0.1.10 -> 0.1.11
- **vLLM**: v0.26.0 -> v0.27.1
