### PR TITLE
chore(apt): refresh Ubuntu snapshot policy

### DIFF
--- a/locks/apt-sources.list
+++ b/locks/apt-sources.list
@@ -1,6 +1,6 @@
 # Pinned apt repositories for reproducible builds.
 # snapshot.ubuntu.com provides immutable, point-in-time mirrors of Ubuntu repos.
-# Snapshot date: 2026-07-14T00:00:00Z
+# Snapshot date: 2026-08-11T00:00:00Z
 #
 # The Dockerfile replaces /etc/apt/sources.list with this file and removes
 # all /etc/apt/sources.list.d/ entries before running apt-get update, so
@@ -11,6 +11,6 @@
 # then run scripts/bump.sh to regenerate locks/apt-packages.txt with new
 # versioned entries from the new snapshot.
 
-deb https://snapshot.ubuntu.com/ubuntu/20260714T000000Z/ noble main restricted universe multiverse
-deb https://snapshot.ubuntu.com/ubuntu/20260714T000000Z/ noble-updates main restricted universe multiverse
-deb https://snapshot.ubuntu.com/ubuntu/20260714T000000Z/ noble-security main restricted universe multiverse
+deb https://snapshot.ubuntu.com/ubuntu/20260811T000000Z/ noble main restricted universe multiverse
+deb https://snapshot.ubuntu.com/ubuntu/20260811T000000Z/ noble-updates main restricted universe multiverse
+deb https://snapshot.ubuntu.com/ubuntu/20260811T000000Z/ noble-security main restricted universe multiverse

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -540,6 +540,7 @@ print((datetime.now(timezone.utc) - snap).days)
     printf 'INFO    %-30s age=%d days (snapshot=%s) - consider refreshing soon\n' \
       "apt snapshot" "${APT_SNAPSHOT_AGE}" "${APT_SNAPSHOT_DISPLAY}"
     if [[ "${DO_BUMP_APT}" -eq 1 ]]; then
+      UPDATES=$((UPDATES + 1))
       update_apt_snapshot "${TODAY_STAMP}"
     fi
   else

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -509,7 +509,7 @@ fi
 # ---------------------------------------------------------------------------
 # apt snapshot age - locks/apt-sources.list
 # Flag stale snapshots so noble-security patches don't go unnoticed.
-# Threshold: INFO >= 30 days, UPDATE >= 60 days.
+# Threshold: INFO >= 7 days, UPDATE >= 60 days.
 # Use --bump-apt-snapshot (locally, never in CI) to advance the date.
 # ---------------------------------------------------------------------------
 
@@ -536,7 +536,7 @@ print((datetime.now(timezone.utc) - snap).days)
     if [[ "${DO_BUMP_APT}" -eq 1 ]]; then
       update_apt_snapshot "${TODAY_STAMP}"
     fi
-  elif [[ "${APT_SNAPSHOT_AGE}" -ge 30 ]]; then
+  elif [[ "${APT_SNAPSHOT_AGE}" -ge 7 ]]; then
     printf 'INFO    %-30s age=%d days (snapshot=%s) - consider refreshing soon\n' \
       "apt snapshot" "${APT_SNAPSHOT_AGE}" "${APT_SNAPSHOT_DISPLAY}"
     if [[ "${DO_BUMP_APT}" -eq 1 ]]; then
@@ -595,7 +595,7 @@ else
   else
     printf '%d component(s) have updates available.\n' "${UPDATES}"
     echo "Run with --update to write changes to versions.env."
-    if [[ "${APT_SNAPSHOT_AGE:-0}" -ge 60 ]]; then
+    if [[ "${APT_SNAPSHOT_AGE:-0}" -ge 7 ]]; then
       echo "Run with --bump-apt-snapshot to advance locks/apt-sources.list to today."
       echo "  NOTE: this busts the apt-base Docker layer cache (full rebuild). Open a"
       echo "  dedicated PR so the cache bust is intentional and isolated."

--- a/tests/test-apt-inputs.py
+++ b/tests/test-apt-inputs.py
@@ -41,7 +41,7 @@ def main():
 
         temporary.write_text(
             sources.read_text().replace(
-                "20260714T000000Z", "20260715T123456Z"
+                "20260811T000000Z", "20260811T123456Z"
             )
         )
         expect_rejected(VALIDATOR.validate_sources, temporary, "mutable timestamp")

--- a/tests/test-check-updates.py
+++ b/tests/test-check-updates.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -594,8 +594,11 @@ def test_apt_snapshot_bump_only_updates_snapshot():
         env["FAKE_VLLM_TAG"] = "v0.26.0"
         env["FAKE_CURRENT_REQUIREMENTS"] = "1"
         sources = root / "locks" / "apt-sources.list"
-        stale = sources.read_text().replace("20260714T000000Z", "20200101T000000Z")
-        stale = stale.replace("2026-07-14T00:00:00Z", "2020-01-01T00:00:00Z")
+        stale_date = datetime.now(timezone.utc) - timedelta(days=8)
+        stale_stamp = stale_date.strftime("%Y%m%dT000000Z")
+        stale_display = stale_date.strftime("%Y-%m-%dT00:00:00Z")
+        stale = sources.read_text().replace("20260811T000000Z", stale_stamp)
+        stale = stale.replace("2026-08-11T00:00:00Z", stale_display)
         sources.write_text(stale)
         versions_before = (root / "versions.env").read_bytes()
 


### PR DESCRIPTION
Advance the pinned Ubuntu snapshot to 2026-08-11 and flag snapshots for refresh after seven days.

- refresh locks/apt-sources.list
- lower the monitor refresh threshold from 30 days to 7
- update the APT input security fixture

The trusted bump workflow will regenerate apt package pins for the new snapshot.