### PR TITLE
chore(ci): sync Docker Hub description from README

### DIFF
--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -1,0 +1,43 @@
+# .github/workflows/dockerhub-description.yaml
+#
+# Keeps the Docker Hub repository description in sync with README.md.
+# Docker Hub does not pull the README automatically, so this workflow
+# PATCHes the full description whenever the README changes or a release
+# is created.
+#
+# Runs on a GitHub-hosted runner (no GPU or aarch64 needed) and only
+# needs the Docker Hub credentials, which are already used by the
+# build-image.yaml release job.
+#
+# Action SHAs are reviewed and allowlisted in tests/test-ci-security-policy.py.
+
+name: Sync Docker Hub description
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yaml
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  dockerhub-description:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: timothystewart6/vllm-gb10
+          short-description: ${{ github.event.repository.description }}
+          enable-url-completion: true

--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -31,9 +31,11 @@ jobs:
 
     steps:
       - name: Checkout
+        # actions/checkout v4
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Update Docker Hub description
+        # peter-evans/dockerhub-description v5
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/tests/test-ci-security-policy.py
+++ b/tests/test-ci-security-policy.py
@@ -23,6 +23,7 @@ APPROVED_ACTIONS = {
     "docker/metadata-action": "dc802804100637a589fabce1cb79ff13a1411302",
     "docker/setup-buildx-action": "37fe631027851001ddb9b187196cc803df7f5f0e",
     "peter-evans/create-pull-request": "5f6978faf089d4d20b00c7766989d076bb2fc7f1",
+    "peter-evans/dockerhub-description": "1b9a80c056b620d92cedb9d9b5a223409c68ddfa",
     "softprops/action-gh-release": "3d0d9888cb7fd7b750713d6e236d1fcb99157228",
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a small GitHub-hosted workflow that keeps the Docker Hub repository description in sync with README.md. Docker Hub does not pull the README automatically, so the description had drifted from the current bump workflow.

## Reasoning and evidence

The build-image.yaml release job already mirrors image tags to Docker Hub, but the repository description is set once and never updated. The current Docker Hub description still documents the old run-bump.yaml flow. This workflow PATCHes the full description from README.md whenever the README or the workflow itself changes on main, and again on each published release.

## Lifecycle impact

None. This is a new GitHub-hosted workflow that only touches the Docker Hub description. It does not run on the DGX Spark runners and does not affect build, bump, or release automation.

## Security impact

The workflow runs on a GitHub-hosted runner with read-only contents permission. It uses the existing DOCKERHUB_TOKEN secret (a PAT) as the password and adds a DOCKERHUB_USERNAME secret for the username. The peter-evans/dockerhub-description action is pinned by full commit SHA and added to the APPROVED_ACTIONS allowlist in tests/test-ci-security-policy.py. The new workflow contains no self-hosted runner, so the trusted entry point checks do not apply.

## Validation

- tests/test-ci-security-policy.py passes all 23 checks including the new action pin
- Full hosted test suite passes (all 17 test-*.py files)
- actionlint reports no issues on the new workflow
- Workflow YAML parses cleanly

## Checklist

- [x] Read the repository guide and relevant contributor and security documentation
- [x] Searched open and closed issues and PRs and linked related work
- [x] Inspected callers, consumers, generated outputs, and downstream workflow stages
- [x] Reviewed the complete diff and changed-file list
- [x] This change is specific to the GB10 build or CI - not a patch to upstream vLLM, NCCL, FlashInfer, or PyTorch behavior
- [ ] A maintainer reviewed the exact SHA before manually dispatching trusted run-bump.yaml
- [ ] Dockerfile or script changes tested on DGX Spark

## Smoke test output

Not applicable. No Dockerfile or build script changes.

## Upstream issue (if applicable)

None.