### PR TITLE
chore(ci): annotate pinned action versions in workflows

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -89,6 +89,7 @@ jobs:
           fi
 
       - name: Checkout
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
@@ -118,9 +119,11 @@ jobs:
           bash scripts/render-metadata.sh > build-metadata.yaml
 
       - name: Set up Docker Buildx
+        # docker/setup-buildx-action v4
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       - name: Log in to GHCR
+        # docker/login-action v4
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
@@ -158,6 +161,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
+        # docker/metadata-action v6
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302
         with:
           images: ghcr.io/timothystewart6/vllm-gb10
@@ -173,6 +177,7 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: Build and push image to GHCR
+        # docker/build-push-action v7
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
@@ -265,10 +270,12 @@ jobs:
     steps:
       - name: Checkout
         # Needed for tests/smoke-test.sh source.
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Log in to GHCR
         # Required to pull the freshly-pushed image (may be private).
+        # docker/login-action v4
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
@@ -307,6 +314,7 @@ jobs:
             > /tmp/build-artifacts/apt-versions.txt
 
       - name: Upload build artifacts
+        # actions/upload-artifact v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: build-artifacts-${{ github.sha }}
@@ -326,12 +334,14 @@ jobs:
     steps:
       - name: Checkout
         # Needed for `git tag` / `git push` of the release tag.
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           # Release notes compare the current tag with the previous release.
           fetch-depth: 0
 
       - name: Log in to GHCR
+        # docker/login-action v4
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           registry: ghcr.io
@@ -339,6 +349,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        # docker/login-action v4
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: timothystewart6
@@ -376,6 +387,7 @@ jobs:
         # action-gh-release is the de facto standard. It is idempotent: if a
         # release for the tag already exists, it updates it in place rather
         # than failing - so re-running this job is safe.
+        # softprops/action-gh-release v3
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: ${{ needs.build.outputs.canonical_tag }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -28,6 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           # Release notes compare the current tag with the previous release.
@@ -54,6 +55,7 @@ jobs:
         # action-gh-release is idempotent: if the release for this tag
         # already exists (e.g. created inline by build-image.yaml), it
         # updates it in place rather than failing.
+        # softprops/action-gh-release v3
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -14,6 +14,7 @@
 name: Sync Docker Hub description
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -31,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        # actions/checkout v4
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Update Docker Hub description

--- a/.github/workflows/monitor-upstream-releases.yaml
+++ b/.github/workflows/monitor-upstream-releases.yaml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Upload update candidate
         if: steps.check.outputs.has-update == 'true'
+        # actions/upload-artifact v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-monitor-versions-${{ github.run_id }}
@@ -82,6 +83,7 @@ jobs:
           persist-credentials: false
 
       - name: Download update candidate
+        # actions/download-artifact v8
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: release-monitor-versions-${{ github.run_id }}
@@ -128,6 +130,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has-changes == 'true' && steps.existing-pr.outputs.skip-pr == 'false'
+        # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.RELEASE_MONITOR_PAT }}

--- a/.github/workflows/promote-pr.yaml
+++ b/.github/workflows/promote-pr.yaml
@@ -36,6 +36,7 @@ jobs:
 
     steps:
       - name: Checkout trusted workflow implementation
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}

--- a/.github/workflows/run-bump.yaml
+++ b/.github/workflows/run-bump.yaml
@@ -61,6 +61,7 @@ jobs:
           fi
 
       - name: Checkout exact trusted workflow revision
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}

--- a/.github/workflows/test-release-notes.yaml
+++ b/.github/workflows/test-release-notes.yaml
@@ -24,6 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           # Fetch all history and tags so the test harness can simulate
@@ -66,6 +67,7 @@ jobs:
           echo "OK: $INNER_FENCES inner code fences properly escaped"
 
       - name: Upload test output artifact
+        # actions/upload-artifact v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: test-scenarios-output

--- a/.github/workflows/verify-reproducible.yaml
+++ b/.github/workflows/verify-reproducible.yaml
@@ -82,6 +82,7 @@ jobs:
           fi
 
       - name: Checkout
+        # actions/checkout v7
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           ref: ${{ github.sha }}
@@ -114,10 +115,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
+        # docker/setup-buildx-action v4
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
 
       # ── Build 1 of 2 (warm BuildKit cache) ─────────────────────────────────
       - name: Build 1 of 2 (warm cache)
+        # docker/build-push-action v7
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
@@ -159,6 +162,7 @@ jobs:
 
       # ── Build 2 of 2 (no-cache - full rebuild from scratch) ────────────────
       - name: Build 2 of 2 (no-cache)
+        # docker/build-push-action v7
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
@@ -249,6 +253,7 @@ jobs:
 
       - name: Upload artifacts and diffs
         if: always()
+        # actions/upload-artifact v7
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: verify-reproducible-${{ github.run_id }}


### PR DESCRIPTION
## What does this PR do?

Adds a version comment above every pinned action across all workflows, so the SHA pins are easier to scan. Also corrects the actions/checkout comment in dockerhub-description.yaml (it was labeled v4 but the pinned SHA is v7) and adds workflow_dispatch to that workflow so the description sync can be re-triggered manually.

## Reasoning and evidence

The workflows pin every external action by full commit SHA, but none of them record which release version that SHA corresponds to. That makes review and Dependabot updates harder to reason about. This change adds a `# <action> v<major>` comment above each `uses:` line. The versions were resolved by matching each pinned SHA to its release tag.

## Lifecycle impact

None. Comments only, plus a workflow_dispatch trigger on the description sync workflow. No build, bump, or release behavior changes.

## Security impact

No new actions and no SHA changes. The workflow_dispatch trigger lets a maintainer re-run the description sync manually, which is needed to recover the startup failure from the initial merge (the workflow ran before the DOCKERHUB_USERNAME secret existed). The action allowlist in tests/test-ci-security-policy.py is unchanged.

## Validation

- tests/test-ci-security-policy.py passes all 23 checks
- Full hosted test suite passes (all 17 test-*.py files)
- actionlint reports no issues on any workflow
- All workflow YAML files parse cleanly

## Checklist

- [x] Read the repository guide and relevant contributor and security documentation
- [x] Searched open and closed issues and PRs and linked related work
- [x] Inspected callers, consumers, generated outputs, and downstream workflow stages
- [x] Reviewed the complete diff and changed-file list
- [x] This change is specific to the GB10 build or CI - not a patch to upstream vLLM, NCCL, FlashInfer, or PyTorch behavior
- [ ] A maintainer reviewed the exact SHA before manually dispatching trusted run-bump.yaml
- [ ] Dockerfile or script changes tested on DGX Spark

## Smoke test output

Not applicable. No Dockerfile or build script changes.

## Upstream issue (if applicable)

None.