### PR TITLE
docs(contributing): require tests for every behavior change in PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ when they exist. Do not open a pull request until the failure is reproduced by
 a test or a documented manual check. A regression test must fail for the
 original reason and pass after the fix.
 
+Every behavior change must ship with a test. A pull request that changes
+behavior without adding or updating a test will not be merged. When a change
+has no testable behavior, say so explicitly in the pull request instead of
+leaving the test gap unaddressed.
+
 Before finalizing a pull request, inspect the complete diff and changed-file
 list, run every applicable validation command, test the state produced by
 automation when generated files are involved, and update documentation and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,8 +190,14 @@ If the issue is upstream, please file it there directly:
 - Search open and closed issues and pull requests before starting.
 - Explain the invariant that failed, the root cause or bounded hypothesis, and
   every upstream and downstream stage inspected.
-- Include a regression that fails for the original reason and passes with the
-  fix. For generated changes, test the resulting repository state.
+- Add a test for every behavior change. A regression must fail for the
+  original reason and pass with the fix. For generated changes, test the
+  resulting repository state. A PR that changes behavior without a test will
+  not be merged. If a change has no testable behavior, state that explicitly
+  in the PR.
+- Run the hosted test suite with `for test_file in tests/test-*.py; do python3
+  "$test_file"; done`, plus shell syntax, ShellCheck, actionlint, and
+  `git diff --check`, and include the results.
 - Complete the reasoning, lifecycle, security, and validation sections in the
   pull request template.
 - Include the output of the smoke test (`tests/smoke-test.sh`) if you changed


### PR DESCRIPTION
PRs have been landing without tests. The guidance existed but was not prominent enough in the instruction files that agents read.

Adds an explicit requirement that every behavior change ships with a test.

- AGENTS.md now states that a PR changing behavior without a test will not be merged, and that a change with no testable behavior must say so explicitly
- CONTRIBUTING.md's Opening a PR section now requires a test for every behavior change and lists the hosted test suite command to run and include