### PR TITLE
fix(monitor): detect updates already included in any open PR

### DIFF
--- a/scripts/check-duplicate-pr.py
+++ b/scripts/check-duplicate-pr.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """
-Check if an open deps/bump PR already exists with identical versions.env changes.
+Check if any open PR already includes the same versions.env changes.
+
+The check scans every open PR (any author, any branch) and compares its
+substantive versions.env changes against the working tree. It skips when an
+open PR already includes the candidate update, so the release monitor does not
+create a duplicate when the update is already covered by a dependabot PR or any
+other open PR.
 
 Returns exit code 0 (skip), 10 (proceed), or 2 (known error) and prints a
 user-facing message.
@@ -12,7 +18,7 @@ Environment:
   GH_TOKEN: GitHub token for gh CLI authentication
 
 Exit codes:
-  0 - Skip: an existing open PR already has the same versions.env changes
+  0 - Skip: an existing open PR already includes the same versions.env changes
       (or no changes to versions.env in working tree)
  10 - Proceed: no matching PR found, caller should create a new one
   2 - Error: the duplicate check could not be completed reliably
@@ -114,17 +120,15 @@ def check_for_duplicate():
         print("No substantive changes to versions.env in working tree")
         return True
 
-    # Find all open deps/bump PRs by this actor
+    # Find all open PRs. We deliberately do not filter by author or branch
+    # namespace: the update may already be included in a dependabot PR, a PR
+    # from another author, or a PR outside the deps/bump namespace. The
+    # versions.env diff comparison below is the real signal, so a broad query
+    # is safe and catches updates that are already covered elsewhere.
     result = run_gh(
         [
             "pr", "list",
             "--state", "OPEN",
-            "--author", "@me",
-            # Match the deps/bump head branch namespace precisely. A plain text
-            # search for "deps/bump" also matches unrelated PRs whose title or
-            # body mentions "deps/bump", which is noisy and can mask a missing
-            # real candidate.
-            "--search", "head:deps/bump",
             "--json", "number,headRefName",
             "--jq", ".[]",
         ],
@@ -136,7 +140,7 @@ def check_for_duplicate():
 
     prs_text = result.stdout.strip()
     if not prs_text:
-        print("No open deps/bump PRs by this actor")
+        print("No open PRs")
         return False
 
     # gh --jq '.[]' outputs one JSON object per line (NDJSON) when there are
@@ -183,11 +187,15 @@ def check_for_duplicate():
                         lines.add(line)
             return lines
 
-        if substantive_lines(branch_diff_vs_main) == substantive_lines(working_diff):
-            print(f"PR #{number} has matching versions.env -- skipping duplicate")
+        # Skip when the candidate update is a subset of the PR's changes. This
+        # recognizes an update that is already included in a larger PR (for
+        # example a dependabot PR that also carries a versions.env bump), not
+        # just a PR that changes exactly the same set of lines.
+        if substantive_lines(working_diff) <= substantive_lines(branch_diff_vs_main):
+            print(f"PR #{number} already includes the update -- skipping duplicate")
             return True
         else:
-            print(f"PR #{number} has different versions.env -- not a match")
+            print(f"PR #{number} does not include the update -- not a match")
 
     print("No matching PR found -- will create new one")
     return False

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -13,8 +13,12 @@ Scenario coverage:
   - Single PR with different substantive changes (proceed)
   - Single PR with same UV but different GB10_BUILD (skip - same substantive, GB10 ignored)
   - Dependabot PR with matching versions.env change (skip)
+  - Dependabot PR with no versions.env change (proceed - action-only PR does not cover the update)
   - Larger PR includes the candidate update as a subset (skip)
   - PR changes the same variable to a different value (proceed)
+  - Candidate has more changes than the PR (partial coverage, proceed)
+  - Multiple PRs, each partially covers, none fully (proceed)
+  - PR superset but shared variable has a different value (proceed)
   - Multiple PRs, none matching (proceed)
   - Multiple PRs, second one matches (skip)
   - Multiple PRs, all match (skip - first match short-circuits)
@@ -122,6 +126,22 @@ index abc1234..def5678 100644
 +UV_VERSION=0.12.0
 """
 
+# Diff that bumps UV_VERSION to a different value AND changes VLLM_REF. Used to
+# prove a superset PR does not suppress the candidate when the shared variable
+# is changed to a different target version.
+UV_DIFFERENT_AND_VLLM_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -20,6 +20,6 @@ GB10_BUILD=2
+-UV_VERSION=0.11.29
++UV_VERSION=0.12.0
+@@ -28,6 +28,6 @@ GB10_BUILD=2
+-VLLM_REF=v0.24.0
++VLLM_REF=v0.25.1
+"""
+
 if __name__ == "__main__":
     import os
     import subprocess
@@ -212,6 +232,14 @@ if __name__ == "__main__":
             0,  # skip (update already in a dependabot PR)
         ),
         (
+            "Dependabot PR with no versions.env change (does not suppress, proceed)",
+            '{"number": 118, "headRefName": "dependabot/github_actions/softprops/action-gh-release-3.0.3"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_base": {"dependabot/github_actions/softprops/action-gh-release-3.0.3": None},
+             "fetch_exit": 0},
+            10,  # proceed (an action-only dependabot PR does not cover the uv update)
+        ),
+        (
             "Larger PR includes the candidate update as a subset (skip)",
             '{"number": 42, "headRefName": "deps/bump-42"}',
             {"working_diff": UV_AND_GB10_DIFF,
@@ -226,6 +254,30 @@ if __name__ == "__main__":
              "branch_diffs_vs_base": {"deps/bump-42": UV_DIFFERENT_DIFF},
              "fetch_exit": 0},
             10,  # proceed (same variable but a different target version)
+        ),
+        (
+            "Candidate has more changes than the PR (partial coverage, proceed)",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_VLLM_DIFF,
+             "branch_diffs_vs_base": {"deps/bump-42": SIMPLE_UV_DIFF},
+             "fetch_exit": 0},
+            10,  # proceed (the PR only covers UV, not the VLLM change)
+        ),
+        (
+            "Multiple PRs, each partially covers, none fully (proceed)",
+            '{"number": 41, "headRefName": "deps/bump-41"}\n{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_VLLM_DIFF,
+             "branch_diffs_vs_base": {"deps/bump-41": SIMPLE_UV_DIFF, "deps/bump-42": VLLM_AND_GB10_DIFF},
+             "fetch_exit": 0},
+            10,  # proceed (no single PR covers both UV and VLLM)
+        ),
+        (
+            "PR superset but shared variable has a different value (proceed)",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_base": {"deps/bump-42": UV_DIFFERENT_AND_VLLM_DIFF},
+             "fetch_exit": 0},
+            10,  # proceed (PR changes UV to a different version, so it does not cover the candidate)
         ),
         (
             "Shallow checkout: origin/main not a local ref, matching change (skip duplicate)",
@@ -373,9 +425,10 @@ if __name__ == "__main__":
                 # Require the query to scan all open PRs. A regression back to
                 # an author or branch-namespace filter (which would miss
                 # dependabot PRs and PRs from other authors) is caught (exit 3
-                # becomes a script error / workflow failure).
-                f.write('bad=0; for a in "$@"; do [ "$a" = "--author" ] && bad=1; [ "$a" = "--search" ] && bad=1; done\n')
-                f.write("[ $bad -eq 0 ] || exit 3\n")
+                # becomes a script error / workflow failure). Also require the
+                # query to be scoped to open PRs only.
+                f.write('state_ok=0; bad=0; for a in "$@"; do [ "$a" = "--state" ] && state_ok=1; [ "$a" = "--author" ] && bad=1; [ "$a" = "--search" ] && bad=1; done\n')
+                f.write("[ $state_ok -eq 1 ] && [ $bad -eq 0 ] || exit 3\n")
                 if fake_gh_stdout:
                     f.write(f'cat << \'ENDJSON\'\n{fake_gh_stdout}\nENDJSON\n')
                 f.write(f"exit {gh_exit}\n")
@@ -498,6 +551,28 @@ if __name__ == "__main__":
     check(
         "cancel-in-progress: false" in workflow,
         "Workflow must let the active monitor run finish before starting another",
+    )
+
+    # Static regression guards on the script source. These protect the core
+    # invariant that the duplicate check scans all open PRs regardless of
+    # author or branch namespace, and that it only considers open PRs.
+    with open(script_path) as script_file:
+        source = script_file.read()
+    check(
+        '"--state", "OPEN"' in source,
+        "Script must scope the PR query to open PRs only",
+    )
+    check(
+        '"--author"' not in source,
+        "Script must not filter PRs by author (would miss dependabot and other authors)",
+    )
+    check(
+        '"--search"' not in source,
+        "Script must not filter PRs by branch namespace (would miss dependabot PRs)",
+    )
+    check(
+        "<= substantive_lines(branch_diff_vs_main)" in source,
+        "Script must use subset matching so an update already included in a larger PR is recognized",
     )
 
     print(f"FAIL: {failed}")

--- a/tests/test-check-duplicate-pr.py
+++ b/tests/test-check-duplicate-pr.py
@@ -12,6 +12,9 @@ Scenario coverage:
   - Single PR with only GB10_BUILD diff, working tree has UV (proceed - different substantive)
   - Single PR with different substantive changes (proceed)
   - Single PR with same UV but different GB10_BUILD (skip - same substantive, GB10 ignored)
+  - Dependabot PR with matching versions.env change (skip)
+  - Larger PR includes the candidate update as a subset (skip)
+  - PR changes the same variable to a different value (proceed)
   - Multiple PRs, none matching (proceed)
   - Multiple PRs, second one matches (skip)
   - Multiple PRs, all match (skip - first match short-circuits)
@@ -91,6 +94,32 @@ index abc1234..def5678 100644
 @@ -14,6 +14,6 @@ CUDA_BASE_DIGEST=sha256:a5b6256e470196fc1d5f8f62139d57d3662867746dfe1cb352d76
 -GB10_BUILD=2
 +GB10_BUILD=3
+"""
+
+# Diff with BOTH UV_VERSION and VLLM_REF change (a larger PR that includes the
+# UV bump as a subset of its changes)
+UV_AND_VLLM_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -20,6 +20,6 @@ GB10_BUILD=2
+-UV_VERSION=0.11.29
++UV_VERSION=0.11.30
+@@ -28,6 +28,6 @@ GB10_BUILD=2
+-VLLM_REF=v0.24.0
++VLLM_REF=v0.25.1
+"""
+
+# Diff that bumps UV_VERSION to a different value than the candidate
+UV_DIFFERENT_DIFF = """\
+diff --git a/versions.env b/versions.env
+index abc1234..def5678 100644
+--- a/versions.env
++++ b/versions.env
+@@ -20,6 +20,6 @@ GB10_BUILD=2
+-UV_VERSION=0.11.29
++UV_VERSION=0.12.0
 """
 
 if __name__ == "__main__":
@@ -173,6 +202,30 @@ if __name__ == "__main__":
              "branch_diffs_vs_base": {"deps/bump-42": SIMPLE_UV_DIFF},
              "fetch_exit": 0},
             0,  # skip (same UV change, GB10_BUILD differs but ignored)
+        ),
+        (
+            "Dependabot PR with matching versions.env change (skip)",
+            '{"number": 118, "headRefName": "dependabot/github_actions/softprops/action-gh-release-3.0.3"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_base": {"dependabot/github_actions/softprops/action-gh-release-3.0.3": UV_AND_GB10_DIFF},
+             "fetch_exit": 0},
+            0,  # skip (update already in a dependabot PR)
+        ),
+        (
+            "Larger PR includes the candidate update as a subset (skip)",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_base": {"deps/bump-42": UV_AND_VLLM_DIFF},
+             "fetch_exit": 0},
+            0,  # skip (candidate UV change is a subset of the PR's changes)
+        ),
+        (
+            "PR changes the same variable to a different value (proceed)",
+            '{"number": 42, "headRefName": "deps/bump-42"}',
+            {"working_diff": UV_AND_GB10_DIFF,
+             "branch_diffs_vs_base": {"deps/bump-42": UV_DIFFERENT_DIFF},
+             "fetch_exit": 0},
+            10,  # proceed (same variable but a different target version)
         ),
         (
             "Shallow checkout: origin/main not a local ref, matching change (skip duplicate)",
@@ -317,11 +370,12 @@ if __name__ == "__main__":
             mock_gh = os.path.join(tmpdir, "gh")
             with open(mock_gh, "w") as f:
                 f.write("#!/usr/bin/env bash\n")
-                # Require the head-branch search qualifier so a regression back
-                # to a broad "deps/bump" text search is caught (exit 3 becomes
-                # a script error / workflow failure).
-                f.write('search_ok=0; for a in "$@"; do [ "$a" = "head:deps/bump" ] && search_ok=1; done\n')
-                f.write("[ $search_ok -eq 1 ] || exit 3\n")
+                # Require the query to scan all open PRs. A regression back to
+                # an author or branch-namespace filter (which would miss
+                # dependabot PRs and PRs from other authors) is caught (exit 3
+                # becomes a script error / workflow failure).
+                f.write('bad=0; for a in "$@"; do [ "$a" = "--author" ] && bad=1; [ "$a" = "--search" ] && bad=1; done\n')
+                f.write("[ $bad -eq 0 ] || exit 3\n")
                 if fake_gh_stdout:
                     f.write(f'cat << \'ENDJSON\'\n{fake_gh_stdout}\nENDJSON\n')
                 f.write(f"exit {gh_exit}\n")


### PR DESCRIPTION
## What does this PR do?

Broadens the release monitor's duplicate check so it scans every open PR instead of only the release monitor's own deps/bump PRs, and skips when an open PR already includes the candidate update.

## Reasoning and evidence

The monitor created #119 (uv 0.12.7 to 0.12.9) even though the same uv bump was already present in #118, a dependabot PR. The duplicate check in `scripts/check-duplicate-pr.py` was scoped to `--author @me` and `--search head:deps/bump`, so it only ever considered the release monitor's own deps/bump PRs and never saw dependabot PRs or PRs from other authors.

The fix removes both filters so the check scans all open PRs, and changes the match from exact equality to subset matching so an update already included in a larger PR is recognized.

## Lifecycle impact

Detection and PR creation in the Monitor Upstream Releases workflow. The duplicate check now considers all open PRs. No change to `versions.env`, build inputs, locks, or release metadata.

## Security impact

The check runs in the create-pr job with the `RELEASE_MONITOR_PAT`. Broadening the query only reads PR metadata and branch contents. It does not change the trust boundary or add any new token use. The check still fails closed on any error.

## Validation

- `python3 tests/test-check-duplicate-pr.py` passes all 31 checks, including new dependabot, subset, and different-version scenarios
- Full hosted test suite passes (all `test-*.py` green)
- Verified live that `gh pr list --state OPEN` returns both #118 and #119

## Checklist

- [x] Read the repository guide and relevant contributor and security documentation
- [x] Searched open and closed issues and PRs and linked related work
- [x] Inspected callers, consumers, generated outputs, and downstream workflow stages
- [x] Added a regression that fails for the original reason and passes with this fix
- [x] Reviewed the complete diff and changed-file list
- [x] This change is specific to the GB10 build or CI - not a patch to upstream vLLM, NCCL, FlashInfer, or PyTorch behavior
- [ ] `versions.env` changes follow the [input integration checklist](../CONTRIBUTING.md#adding-or-changing-a-versionsenv-input)
- [ ] A maintainer reviewed the exact SHA before manually dispatching trusted `run-bump.yaml`
- [ ] Dockerfile or script changes tested on DGX Spark
- [ ] Smoke test output included below if Dockerfile or build scripts changed
